### PR TITLE
GetAll2000UseCase

### DIFF
--- a/app/src/main/java/com/example/seoulpublicservice/SeoulPublicServiceApplication.kt
+++ b/app/src/main/java/com/example/seoulpublicservice/SeoulPublicServiceApplication.kt
@@ -10,6 +10,6 @@ class SeoulPublicServiceApplication : Application() {
     val container get() = _container
     override fun onCreate() {
         super.onCreate()
-        _container = DefaultAppContainer()
+        _container = DefaultAppContainer(this)
     }
 }

--- a/app/src/main/java/com/example/seoulpublicservice/di/AppContainer.kt
+++ b/app/src/main/java/com/example/seoulpublicservice/di/AppContainer.kt
@@ -1,6 +1,11 @@
 package com.example.seoulpublicservice.di
 
+import android.content.Context
 import com.example.seoulpublicservice.BuildConfig
+import com.example.seoulpublicservice.pref.PrefRepository
+import com.example.seoulpublicservice.pref.PrefRepositoryImpl
+import com.example.seoulpublicservice.pref.RowPrefRepository
+import com.example.seoulpublicservice.pref.RowPrefRepositoryImpl
 import com.example.seoulpublicservice.seoul.SeoulApiService
 import com.example.seoulpublicservice.seoul.SeoulPublicRepositoryImpl
 import com.example.seoulpublicservice.usecase.GetAllFirst1000UseCase
@@ -10,15 +15,19 @@ import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import java.util.concurrent.TimeUnit
 
-///** 클린아키텍쳐 하다가 정 안되면 그냥 이렇게 전역으로 놓고 쓰면 어디서든 사용 가능... */
+///** 클린아키텍쳐 하다가 정 안되면 그냥 이렇게 전역으로 놓고 쓰면 어디서든 사용 가능...할 줄 알았는데
+// * SharedPreferences나 Room 등 context를 사용하는 것들이 있어서
+// * 애플리케이션 클래스에서 만들어줄 수 밖에 없다. */
 //val myContainer: AppContainer = DefaultAppContainer()
 
 /** Dependency Injection container */
 interface AppContainer {
     val getAllFirst1000UseCase: GetAllFirst1000UseCase
+    val prefRepository: PrefRepository
+    val rowPrefRepository: RowPrefRepository
 }
 
-class DefaultAppContainer : AppContainer {
+class DefaultAppContainer(context: Context) : AppContainer {
     // TODO: retrofit 관련 로직들 따로 빼야 하나
     private val baseUrl = "http://openapi.seoul.go.kr:8088"
 
@@ -58,4 +67,13 @@ class DefaultAppContainer : AppContainer {
     override val getAllFirst1000UseCase: GetAllFirst1000UseCase by lazy {
         GetAllFirst1000UseCase(seoulPublicRepository)
     }
+
+    override val prefRepository: PrefRepository by lazy {
+        PrefRepositoryImpl(context = context)
+    }
+
+    override val rowPrefRepository: RowPrefRepository by lazy {
+        RowPrefRepositoryImpl(context = context)
+    }
+
 }

--- a/app/src/main/java/com/example/seoulpublicservice/di/AppContainer.kt
+++ b/app/src/main/java/com/example/seoulpublicservice/di/AppContainer.kt
@@ -8,7 +8,7 @@ import com.example.seoulpublicservice.pref.RowPrefRepository
 import com.example.seoulpublicservice.pref.RowPrefRepositoryImpl
 import com.example.seoulpublicservice.seoul.SeoulApiService
 import com.example.seoulpublicservice.seoul.SeoulPublicRepositoryImpl
-import com.example.seoulpublicservice.usecase.GetAllFirst1000UseCase
+import com.example.seoulpublicservice.usecase.GetAll2000UseCase
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit
 
 /** Dependency Injection container */
 interface AppContainer {
-    val getAllFirst1000UseCase: GetAllFirst1000UseCase
+    val getAll2000UseCase: GetAll2000UseCase
     val prefRepository: PrefRepository
     val rowPrefRepository: RowPrefRepository
 }
@@ -64,8 +64,8 @@ class DefaultAppContainer(context: Context) : AppContainer {
 //        SeoulPublicRepositoryImpl(retrofitService)
 //    }
 
-    override val getAllFirst1000UseCase: GetAllFirst1000UseCase by lazy {
-        GetAllFirst1000UseCase(
+    override val getAll2000UseCase: GetAll2000UseCase by lazy {
+        GetAll2000UseCase(
             seoulPublicRepository = seoulPublicRepository,
             prefRepository = prefRepository,
             rowPrefRepository = rowPrefRepository

--- a/app/src/main/java/com/example/seoulpublicservice/di/AppContainer.kt
+++ b/app/src/main/java/com/example/seoulpublicservice/di/AppContainer.kt
@@ -65,7 +65,11 @@ class DefaultAppContainer(context: Context) : AppContainer {
 //    }
 
     override val getAllFirst1000UseCase: GetAllFirst1000UseCase by lazy {
-        GetAllFirst1000UseCase(seoulPublicRepository)
+        GetAllFirst1000UseCase(
+            seoulPublicRepository = seoulPublicRepository,
+            prefRepository = prefRepository,
+            rowPrefRepository = rowPrefRepository
+        )
     }
 
     override val prefRepository: PrefRepository by lazy {

--- a/app/src/main/java/com/example/seoulpublicservice/pref/PrefRepository.kt
+++ b/app/src/main/java/com/example/seoulpublicservice/pref/PrefRepository.kt
@@ -1,0 +1,31 @@
+package com.example.seoulpublicservice.pref
+
+import android.content.Context
+import android.util.Log
+
+/** 그냥 String으로 key, value 넣어서 사용할 수 있는 Repository.
+ * 별로 권장하지는 않습니다. 용도에 따라 Repository를 만들어 사용하는 걸 추천. */
+interface PrefRepository {
+    fun save(key: String, value: String)
+    fun load(key: String): String
+}
+
+class PrefRepositoryImpl(context: Context) : PrefRepository {
+
+    private val pref = context.getSharedPreferences("DefaultPrefRepository", Context.MODE_PRIVATE)
+
+    override fun save(key: String, value: String) {
+        pref.edit().putString(key, value).apply()
+    }
+
+    override fun load(key: String): String {
+        val loaded = pref.getString(key, null) ?: return ""
+            .apply { Log.w("jj-PrefRepositoryImpl", "load $key got null") }
+
+        val s = if (loaded.length <= 63) loaded else loaded.substring(0, 63)
+        Log.d("jj-PrefRepositoryImpl", "loaded $key: $s")
+
+        return loaded
+    }
+
+}

--- a/app/src/main/java/com/example/seoulpublicservice/pref/RowPrefRepository.kt
+++ b/app/src/main/java/com/example/seoulpublicservice/pref/RowPrefRepository.kt
@@ -1,7 +1,6 @@
 package com.example.seoulpublicservice.pref
 
 import android.content.Context
-import android.util.Log
 import com.example.seoulpublicservice.seoul.Row
 import com.google.gson.Gson
 
@@ -20,18 +19,22 @@ class RowPrefRepositoryImpl(context: Context) : RowPrefRepository {
     }
 
     override fun saveRows(rowList: List<Row>) {
-        val json = gson.toJson(rowList)
-        pref.edit().putString(Key.rows, json).apply()
+        // TODO: 약 1600개 저장하다가 메모리 터짐. 한 512개씩 나눠서 분할 저장해야 할 듯. 그보다 Room으로.
+
+//        val json = gson.toJson(rowList)
+//        pref.edit().putString(Key.rows, json).apply()
     }
 
     override fun loadRows(): List<Row> {
-        val json = pref.getString(Key.rows, null) ?: return emptyList<Row>()
-            .apply { Log.w("jj-RowPrefRepositoryImpl", "loadRows got null") }
+//        val json = pref.getString(Key.rows, null) ?: return emptyList<Row>()
+//            .apply { Log.w("jj-RowPrefRepositoryImpl", "loadRows got null") }
+//
+//        val s = if (json.length <= 63) json else json.substring(0, 63)
+//        Log.d("jj-RowPrefRepositoryImpl", "loadRows json: $s")
+//
+//        return gson.fromJson(json, Array<Row>::class.java).toList()
 
-        val s = if (json.length <= 63) json else json.substring(0, 63)
-        Log.d("jj-RowPrefRepositoryImpl", "loadRows json: $s")
-
-        return gson.fromJson(json, Array<Row>::class.java).toList()
+        return emptyList()
     }
 
 }

--- a/app/src/main/java/com/example/seoulpublicservice/pref/RowPrefRepository.kt
+++ b/app/src/main/java/com/example/seoulpublicservice/pref/RowPrefRepository.kt
@@ -1,0 +1,37 @@
+package com.example.seoulpublicservice.pref
+
+import android.content.Context
+import android.util.Log
+import com.example.seoulpublicservice.seoul.Row
+import com.google.gson.Gson
+
+interface RowPrefRepository {
+    fun saveRows(rowList: List<Row>)
+    fun loadRows(): List<Row>
+}
+
+class RowPrefRepositoryImpl(context: Context) : RowPrefRepository {
+
+    private val pref = context.getSharedPreferences("RowList", Context.MODE_PRIVATE)
+    private val gson = Gson()
+
+    private data object Key {
+        const val rows = "rows"
+    }
+
+    override fun saveRows(rowList: List<Row>) {
+        val json = gson.toJson(rowList)
+        pref.edit().putString(Key.rows, json).apply()
+    }
+
+    override fun loadRows(): List<Row> {
+        val json = pref.getString(Key.rows, null) ?: return emptyList<Row>()
+            .apply { Log.w("jj-RowPrefRepositoryImpl", "loadRows got null") }
+
+        val s = if (json.length <= 63) json else json.substring(0, 63)
+        Log.d("jj-RowPrefRepositoryImpl", "loadRows json: $s")
+
+        return gson.fromJson(json, Array<Row>::class.java).toList()
+    }
+
+}

--- a/app/src/main/java/com/example/seoulpublicservice/seoul/SeoulApiService.kt
+++ b/app/src/main/java/com/example/seoulpublicservice/seoul/SeoulApiService.kt
@@ -3,8 +3,17 @@ package com.example.seoulpublicservice.seoul
 import com.example.seoulpublicservice.BuildConfig
 import retrofit2.Response
 import retrofit2.http.GET
+import retrofit2.http.Path
 
 interface SeoulApiService {
+
     @GET("/${BuildConfig.SEOUL_KEY}/json/tvYeyakCOllect/1/1000/")
-    suspend fun getAllFirst1000(): Response<SeoulDto>
+    suspend fun getAll1000(): Response<SeoulDto>
+
+    @GET("/${BuildConfig.SEOUL_KEY}/json/tvYeyakCOllect/{startIndex}/{endIndex}/")
+    suspend fun getAllRange(
+        @Path("startIndex") startIndex: Int,
+        @Path("endIndex") endIndex: Int
+    ): Response<SeoulDto>
+
 }

--- a/app/src/main/java/com/example/seoulpublicservice/seoul/SeoulPublicRepository.kt
+++ b/app/src/main/java/com/example/seoulpublicservice/seoul/SeoulPublicRepository.kt
@@ -1,30 +1,86 @@
 package com.example.seoulpublicservice.seoul
 
 import android.util.Log
+import com.example.seoulpublicservice.util.trimUpTo
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import retrofit2.Response
 
 interface SeoulPublicRepository {
     /** 종합으로 첫 천개 가져오기 */
-    suspend fun getAllFirst1000(): List<Row>
+    suspend fun getAll1000(): List<Row>
+
+    /** 종합으로 2천개 가져오기 */
+    suspend fun getAll2000(): List<Row>
 }
 
 class SeoulPublicRepositoryImpl(
     private val seoulApiService: SeoulApiService
 ) : SeoulPublicRepository {
-    override suspend fun getAllFirst1000(): List<Row> {
-        val response = seoulApiService.getAllFirst1000()
-        Log.d(
-            "jj-SeoulPublicRepositoryImpl",
-            "listTotalCount: ${response.body()?.tvYeyakCOllect?.listTotalCount}, " +
-                    "result: ${response.body()?.tvYeyakCOllect?.result}"
-        )
-        val s = response.body()?.tvYeyakCOllect?.rowList?.firstOrNull().toString().let {
-            if (it.length <= 64) it else it.substring(0, 64)
+
+    override suspend fun getAll1000(): List<Row> {
+        val response = seoulApiService.getAll1000()
+        val body = response.body()
+        if (body == null) {
+            Log.d(
+                "jj-SeoulPublicRepositoryImpl",
+                "getAll1000 body == null"
+            )
+        } else {
+            val s =
+                "total: ${body.tvYeyakCOllect.listTotalCount}, ${body.tvYeyakCOllect.result}\n" +
+                        body.tvYeyakCOllect.rowList.firstOrNull().toString().trimUpTo(127)
+            Log.d(
+                "jj-SeoulPublicRepositoryImpl",
+                "getAll1000 응답: $s"
+            )
         }
-        Log.d("jj-SeoulPublicRepositoryImpl", "first row length 64: $s")
         return convertResponseToItems(response)
+    }
+
+    override suspend fun getAll2000(): List<Row> = coroutineScope {
+        val deferred1 = async {
+            val response = seoulApiService.getAllRange(1, 1000)
+            val body = response.body()
+            if (body == null) {
+                Log.d(
+                    "jj-SeoulPublicRepositoryImpl",
+                    "getAll2000 천 천개 body == null"
+                )
+            } else {
+                val s =
+                    "total: ${body.tvYeyakCOllect.listTotalCount}, ${body.tvYeyakCOllect.result}\n" +
+                            body.tvYeyakCOllect.rowList.firstOrNull().toString().trimUpTo(127)
+                Log.d(
+                    "jj-SeoulPublicRepositoryImpl",
+                    "getAll2000 천 천개 응답: $s"
+                )
+            }
+            convertResponseToItems(response)
+        }
+        val deferred2 = async {
+            val response = seoulApiService.getAllRange(1001, 2000)
+            val body = response.body()
+            if (body == null) {
+                Log.d(
+                    "jj-SeoulPublicRepositoryImpl",
+                    "getAllFirst2000 1001~2000 body == null"
+                )
+            } else {
+                val s =
+                    "total: ${body.tvYeyakCOllect.listTotalCount}, ${body.tvYeyakCOllect.result}\n" +
+                            body.tvYeyakCOllect.rowList.firstOrNull().toString().trimUpTo(127)
+                Log.d(
+                    "jj-SeoulPublicRepositoryImpl",
+                    "getAllFirst2000 1001~2000 응답: $s"
+                )
+            }
+            convertResponseToItems(response)
+        }
+        return@coroutineScope deferred1.await() + deferred2.await()
     }
 
     private fun convertResponseToItems(response: Response<SeoulDto>): List<Row> =
         response.body()?.tvYeyakCOllect?.rowList ?: emptyList()
+
 }

--- a/app/src/main/java/com/example/seoulpublicservice/ui/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/example/seoulpublicservice/ui/notifications/NotificationsViewModel.kt
@@ -9,8 +9,6 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.example.seoulpublicservice.SeoulPublicServiceApplication
-import com.example.seoulpublicservice.pref.PrefRepository
-import com.example.seoulpublicservice.pref.RowPrefRepository
 import com.example.seoulpublicservice.seoul.Row
 import com.example.seoulpublicservice.usecase.GetAllFirst1000UseCase
 import kotlinx.coroutines.Dispatchers
@@ -18,9 +16,7 @@ import kotlinx.coroutines.launch
 import kotlin.random.Random
 
 class NotificationsViewModel(
-    private val getAllFirst1000UseCase: GetAllFirst1000UseCase,
-    private val rowPrefRepository: RowPrefRepository,
-    private val prefRepository: PrefRepository
+    private val getAllFirst1000UseCase: GetAllFirst1000UseCase
 ) : ViewModel() {
 
     private val _text: MutableLiveData<String> =
@@ -30,29 +26,9 @@ class NotificationsViewModel(
     private var rowList: List<Row> = emptyList()
     private val random = Random
 
-    private val tempKeyRowsSavedTime = "tempKeyRowsSavedTime"
-
     fun setRandomOne() {
         if (rowList.isEmpty()) viewModelScope.launch(Dispatchers.IO) {
-            var isRecent = false
-            val rowsSavedTime = prefRepository.load(tempKeyRowsSavedTime).toLongOrNull()
-            if (rowsSavedTime == null) {
-                Log.w(
-                    "jj-노티뷰모델",
-                    "prefRepository.load(tempKeyRowsSavedTime).toLongOrNull() == null"
-                )
-            } else {
-                val timeDiff = System.currentTimeMillis() - rowsSavedTime
-                Log.d("jj-노티뷰모델", "timeDiff: $timeDiff")
-                isRecent = timeDiff < 180_000L
-            }
-
-            if (isRecent) rowList = rowPrefRepository.loadRows()
-            if (rowList.isEmpty()) {
-                rowList = getAllFirst1000UseCase()
-                rowPrefRepository.saveRows(rowList)
-                prefRepository.save(tempKeyRowsSavedTime, System.currentTimeMillis().toString())
-            }
+            rowList = getAllFirst1000UseCase()
 
             val row = rowList.firstOrNull()
             if (row == null) {
@@ -77,9 +53,7 @@ class NotificationsViewModel(
                 val application = (this[APPLICATION_KEY] as SeoulPublicServiceApplication)
                 val container = application.container
                 NotificationsViewModel(
-                    getAllFirst1000UseCase = container.getAllFirst1000UseCase,
-                    rowPrefRepository = container.rowPrefRepository,
-                    prefRepository = container.prefRepository
+                    getAllFirst1000UseCase = container.getAllFirst1000UseCase
                 )
             }
         }

--- a/app/src/main/java/com/example/seoulpublicservice/ui/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/example/seoulpublicservice/ui/notifications/NotificationsViewModel.kt
@@ -9,6 +9,8 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.example.seoulpublicservice.SeoulPublicServiceApplication
+import com.example.seoulpublicservice.pref.PrefRepository
+import com.example.seoulpublicservice.pref.RowPrefRepository
 import com.example.seoulpublicservice.seoul.Row
 import com.example.seoulpublicservice.usecase.GetAllFirst1000UseCase
 import kotlinx.coroutines.Dispatchers
@@ -16,42 +18,69 @@ import kotlinx.coroutines.launch
 import kotlin.random.Random
 
 class NotificationsViewModel(
-    private val getAllFirst1000UseCase: GetAllFirst1000UseCase
+    private val getAllFirst1000UseCase: GetAllFirst1000UseCase,
+    private val rowPrefRepository: RowPrefRepository,
+    private val prefRepository: PrefRepository
 ) : ViewModel() {
 
     private val _text: MutableLiveData<String> =
         MutableLiveData("_text 라이브데이터 초기값 ㅁㄴㅇㄹㅁㄴㅇㄹ")
     val text: LiveData<String> = _text
 
-    private var rowList: List<Row>? = null
+    private var rowList: List<Row> = emptyList()
     private val random = Random
 
+    private val tempKeyRowsSavedTime = "tempKeyRowsSavedTime"
+
     fun setRandomOne() {
-        if (rowList.isNullOrEmpty()) viewModelScope.launch(Dispatchers.IO) {
-            rowList = getAllFirst1000UseCase()
-            val row = rowList!!.firstOrNull()
+        if (rowList.isEmpty()) viewModelScope.launch(Dispatchers.IO) {
+            var isRecent = false
+            val rowsSavedTime = prefRepository.load(tempKeyRowsSavedTime).toLongOrNull()
+            if (rowsSavedTime == null) {
+                Log.w(
+                    "jj-노티뷰모델",
+                    "prefRepository.load(tempKeyRowsSavedTime).toLongOrNull() == null"
+                )
+            } else {
+                val timeDiff = System.currentTimeMillis() - rowsSavedTime
+                Log.d("jj-노티뷰모델", "timeDiff: $timeDiff")
+                isRecent = timeDiff < 180_000L
+            }
+
+            if (isRecent) rowList = rowPrefRepository.loadRows()
+            if (rowList.isEmpty()) {
+                rowList = getAllFirst1000UseCase()
+                rowPrefRepository.saveRows(rowList)
+                prefRepository.save(tempKeyRowsSavedTime, System.currentTimeMillis().toString())
+            }
+
+            val row = rowList.firstOrNull()
             if (row == null) {
-                _text.postValue("rowList.size: ${rowList!!.size}\n\nrowList empty")
+                _text.postValue("rowList.size: ${rowList.size}\n\nrowList empty")
                 Log.w("jj-노티뷰모델", "rowList is empty")
             } else {
-                _text.postValue("rowList.size: ${rowList!!.size}\n\n$row")
+                _text.postValue("rowList.size: ${rowList.size}\n\n$row")
                 Log.d("jj-노티뷰모델", "id: ${row.svcid}")
             }
         }
         else {
-            val row = rowList!![random.nextInt(0, rowList!!.size)]
-            _text.postValue("rowList.size: ${rowList!!.size}\n\n$row")
+            val row = rowList[random.nextInt(0, rowList.size)]
+            _text.postValue("rowList.size: ${rowList.size}\n\n$row")
             Log.d("jj-노티뷰모델", "id: ${row.svcid}")
         }
     }
 
     companion object {
-        /** Factory for [NotificationsViewModel] that takes [GetAllFirst1000UseCase] as a dependency*/
+        /** 뷰모델팩토리에서 의존성주입을 해준다 */
         val factory = viewModelFactory {
             initializer {
                 val application = (this[APPLICATION_KEY] as SeoulPublicServiceApplication)
-                val getAllFirst1000UseCase = application.container.getAllFirst1000UseCase
-                NotificationsViewModel(getAllFirst1000UseCase = getAllFirst1000UseCase)
+                val container = application.container
+                NotificationsViewModel(
+                    getAllFirst1000UseCase = container.getAllFirst1000UseCase,
+                    rowPrefRepository = container.rowPrefRepository,
+                    prefRepository = container.prefRepository
+                )
             }
         }
     }

--- a/app/src/main/java/com/example/seoulpublicservice/ui/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/example/seoulpublicservice/ui/notifications/NotificationsViewModel.kt
@@ -10,13 +10,13 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.example.seoulpublicservice.SeoulPublicServiceApplication
 import com.example.seoulpublicservice.seoul.Row
-import com.example.seoulpublicservice.usecase.GetAllFirst1000UseCase
+import com.example.seoulpublicservice.usecase.GetAll2000UseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlin.random.Random
 
 class NotificationsViewModel(
-    private val getAllFirst1000UseCase: GetAllFirst1000UseCase
+    private val getAll2000UseCase: GetAll2000UseCase
 ) : ViewModel() {
 
     private val _text: MutableLiveData<String> =
@@ -27,8 +27,9 @@ class NotificationsViewModel(
     private val random = Random
 
     fun setRandomOne() {
-        if (rowList.isEmpty()) viewModelScope.launch(Dispatchers.IO) {
-            rowList = getAllFirst1000UseCase()
+        // getAll2000UseCase 처리 시 1600개 정도 데이터를 변환하고 반환하는 과정이 cpu가 좀 필요할 듯 해서 Default로 줌.
+        if (rowList.isEmpty()) viewModelScope.launch(Dispatchers.Default) {
+            rowList = getAll2000UseCase()
 
             val row = rowList.firstOrNull()
             if (row == null) {
@@ -53,7 +54,7 @@ class NotificationsViewModel(
                 val application = (this[APPLICATION_KEY] as SeoulPublicServiceApplication)
                 val container = application.container
                 NotificationsViewModel(
-                    getAllFirst1000UseCase = container.getAllFirst1000UseCase
+                    getAll2000UseCase = container.getAll2000UseCase
                 )
             }
         }

--- a/app/src/main/java/com/example/seoulpublicservice/usecase/GetAll2000UseCase.kt
+++ b/app/src/main/java/com/example/seoulpublicservice/usecase/GetAll2000UseCase.kt
@@ -6,7 +6,7 @@ import com.example.seoulpublicservice.pref.RowPrefRepository
 import com.example.seoulpublicservice.seoul.Row
 import com.example.seoulpublicservice.seoul.SeoulPublicRepository
 
-class GetAllFirst1000UseCase(
+class GetAll2000UseCase(
     private val seoulPublicRepository: SeoulPublicRepository,
     private val prefRepository: PrefRepository,
     private val rowPrefRepository: RowPrefRepository
@@ -20,27 +20,27 @@ class GetAllFirst1000UseCase(
         val rowsSavedTime = prefRepository.load(tempKeyRowsSavedTime).toLongOrNull()
         if (rowsSavedTime == null) {
             Log.w(
-                "jj-GetAllFirst1000UseCase",
+                "jj-GetAll2000UseCase",
                 "prefRepository.load(tempKeyRowsSavedTime).toLongOrNull() == null"
             )
         } else {
             val timeDiff = System.currentTimeMillis() - rowsSavedTime
-            Log.d("jj-GetAllFirst1000UseCase", "timeDiff: $timeDiff")
+            Log.d("jj-GetAll2000UseCase", "timeDiff: $timeDiff")
             isRecent = timeDiff < 180_000L
         }
 
         if (isRecent) {
             rowList = rowPrefRepository.loadRows()
-            if (rowList.isEmpty()) getAllFirst1000()
+            if (rowList.isEmpty()) getAll2000()
         } else {
-            getAllFirst1000()
+            getAll2000()
         }
 
         return rowList
     }
 
-    private suspend fun getAllFirst1000() {
-        rowList = seoulPublicRepository.getAllFirst1000()
+    private suspend fun getAll2000() {
+        rowList = seoulPublicRepository.getAll2000()
         rowPrefRepository.saveRows(rowList)
         prefRepository.save(tempKeyRowsSavedTime, System.currentTimeMillis().toString())
     }

--- a/app/src/main/java/com/example/seoulpublicservice/usecase/GetAllFirst1000UseCase.kt
+++ b/app/src/main/java/com/example/seoulpublicservice/usecase/GetAllFirst1000UseCase.kt
@@ -1,10 +1,48 @@
 package com.example.seoulpublicservice.usecase
 
+import android.util.Log
+import com.example.seoulpublicservice.pref.PrefRepository
+import com.example.seoulpublicservice.pref.RowPrefRepository
 import com.example.seoulpublicservice.seoul.Row
 import com.example.seoulpublicservice.seoul.SeoulPublicRepository
 
 class GetAllFirst1000UseCase(
-    private val seoulPublicRepository: SeoulPublicRepository
+    private val seoulPublicRepository: SeoulPublicRepository,
+    private val prefRepository: PrefRepository,
+    private val rowPrefRepository: RowPrefRepository
 ) {
-    suspend operator fun invoke(): List<Row> = seoulPublicRepository.getAllFirst1000()
+
+    private var rowList: List<Row> = emptyList()
+    private val tempKeyRowsSavedTime = "tempKeyRowsSavedTime"
+
+    suspend operator fun invoke(): List<Row> {
+        var isRecent = false
+        val rowsSavedTime = prefRepository.load(tempKeyRowsSavedTime).toLongOrNull()
+        if (rowsSavedTime == null) {
+            Log.w(
+                "jj-GetAllFirst1000UseCase",
+                "prefRepository.load(tempKeyRowsSavedTime).toLongOrNull() == null"
+            )
+        } else {
+            val timeDiff = System.currentTimeMillis() - rowsSavedTime
+            Log.d("jj-GetAllFirst1000UseCase", "timeDiff: $timeDiff")
+            isRecent = timeDiff < 180_000L
+        }
+
+        if (isRecent) {
+            rowList = rowPrefRepository.loadRows()
+            if (rowList.isEmpty()) getAllFirst1000()
+        } else {
+            getAllFirst1000()
+        }
+
+        return rowList
+    }
+
+    private suspend fun getAllFirst1000() {
+        rowList = seoulPublicRepository.getAllFirst1000()
+        rowPrefRepository.saveRows(rowList)
+        prefRepository.save(tempKeyRowsSavedTime, System.currentTimeMillis().toString())
+    }
+
 }

--- a/app/src/main/java/com/example/seoulpublicservice/util/StringExpandFuncion.kt
+++ b/app/src/main/java/com/example/seoulpublicservice/util/StringExpandFuncion.kt
@@ -1,0 +1,3 @@
+package com.example.seoulpublicservice.util
+
+fun String.trimUpTo(length: Int) = if (this.length <= length) this else this.substring(0, length)


### PR DESCRIPTION
## PR 체크리스트
다음 요구사항을 충족하는지 확인해주세요

- [ ] 커밋메세지 규칙을 따릅니다.

## PR 유형
어떤 변경사항이 있는지 모두 체크해 주세요

- [ ] 기능구현
- [ ] 버그픽스
- [ ] 리팩토링
- [ ] 문서 변경
- [ ] 레이아웃
- [ ] 기타

## 변경사항 작성
이전 PR 브랜치를 포함합니다: [feat: SharedPreferences Repository #7](https://github.com/nbc-SpaceS/temp-name/pull/7)

현재 브랜치의 변경사항은 다음 커밋부터: feat: 2천개 받아오게 바꿈 (내용 참고)

<br>

(커밋 메세지 그대로 여기에도 적어둡니다):

<!-- @ 다음에 영어 붙이니까 깃헙 유저 닉네임 링크가 자동 생성돼서 한칸 띄어 적음 -->
\@ Get의 주소를 \@ Path를 사용해서 동적으로 바꿔서 범위 지정 쿼리 가능해짐.

async await로 1\~1000, 1001\~2000 동시에 \@ Get 보내고 받음.

pref 이용한 Row 리스트 저장은 1000개까지는 됐는데 1600개 정도 하려니 메모리 터짐. pref 캐싱은 현재 빈 리스트만 반환하도록 해둠.

String 길이 제한하는 util 추가.

## Merge 후 브랜치 삭제 여부
- [ ] 반영된 브랜치 삭제
