### PR TITLE
[ Feat ] : 필터페이지 카테고리 클릭시 애니메이션 효과

### DIFF
--- a/app/src/main/java/com/example/seoulpublicservice/InterestRegionSelectActivity.kt
+++ b/app/src/main/java/com/example/seoulpublicservice/InterestRegionSelectActivity.kt
@@ -5,12 +5,13 @@ import android.os.Bundle
 import android.widget.CompoundButton
 import android.widget.Toast
 import androidx.activity.viewModels
-import com.example.seoulpublicservice.databinding.ActivityInterestRegionSelectAcitivtyBinding
+import com.example.seoulpublicservice.databinding.ActivityInterestRegionSelectBinding
+
 
 class InterestRegionSelectActivity : AppCompatActivity() {
 
-    private val binding: ActivityInterestRegionSelectAcitivtyBinding by lazy {
-        ActivityInterestRegionSelectAcitivtyBinding.inflate(layoutInflater)
+    private val binding: ActivityInterestRegionSelectBinding by lazy {
+        ActivityInterestRegionSelectBinding.inflate(layoutInflater)
     }
 
     private val viewModel: InterestRegionSelectViewModel by viewModels { InterestRegionSelectViewModel.factory }

--- a/app/src/main/java/com/example/seoulpublicservice/dialog/filter/FilterFragment.kt
+++ b/app/src/main/java/com/example/seoulpublicservice/dialog/filter/FilterFragment.kt
@@ -5,6 +5,8 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.animation.Animation
+import android.view.animation.AnimationUtils
 import androidx.core.view.isVisible
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
@@ -199,10 +201,22 @@ class FilterFragment(
             header.setOnClickListener {
                 if (chipGroupList[index].isVisible) {
                     moreButtonList[index].setImageResource(R.drawable.ic_more)
+                    val slideUp = AnimationUtils.loadAnimation(requireContext(), R.anim.slide_up)
+                    slideUp.setAnimationListener(object : Animation.AnimationListener {
+                        override fun onAnimationStart(p0: Animation?) = Unit
+                        override fun onAnimationRepeat(p0: Animation?) = Unit
+                        override fun onAnimationEnd(p0: Animation?) {
+                            chipGroupList[index].visibility = View.GONE
+                        }
+                    })
+                    chipGroupList[index].startAnimation(slideUp)
+//                    chipGroupList[index].visibility = View.GONE
                 } else {
                     moreButtonList[index].setImageResource(R.drawable.ic_less)
+                    val slideDown = AnimationUtils.loadAnimation(requireContext(), R.anim.slide_down)
+                    chipGroupList[index].startAnimation(slideDown)
+                    chipGroupList[index].visibility = View.VISIBLE
                 }
-                chipGroupList[index].isVisible = !chipGroupList[index].isVisible
             }
         }
 

--- a/app/src/main/res/anim/slide_down.xml
+++ b/app/src/main/res/anim/slide_down.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:duration="500"
+        android:fromYDelta="-100%"
+        android:toYDelta="0%" />
+</set>

--- a/app/src/main/res/anim/slide_up.xml
+++ b/app/src/main/res/anim/slide_up.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <translate
+        android:duration="500"
+        android:fromYDelta="0%"
+        android:toYDelta="-100%" />
+</set>

--- a/app/src/main/res/layout/activity_interest_region_select.xml
+++ b/app/src/main/res/layout/activity_interest_region_select.xml
@@ -10,9 +10,9 @@
         android:id="@+id/iv_interest_region_select_back_btn"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:src="@drawable/ic_arrow_back"
-        android:layout_marginTop="10dp"
         android:layout_marginStart="10dp"
+        android:layout_marginTop="10dp"
+        android:src="@drawable/ic_arrow_back"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -44,7 +44,7 @@
         <CheckBox
             android:id="@+id/cb_interest_region_select_btn1"
             android:layout_width="75dp"
-            android:layout_height="32dp"
+            android:layout_height="35dp"
             android:layout_marginTop="10dp"
             android:background="@drawable/selector_custom_region_checkbox"
             android:button="@null"
@@ -61,7 +61,7 @@
         <CheckBox
             android:id="@+id/cb_interest_region_select_btn2"
             android:layout_width="75dp"
-            android:layout_height="32dp"
+            android:layout_height="35dp"
             android:background="@drawable/selector_custom_region_checkbox"
             android:button="@null"
             android:gravity="center"
@@ -77,7 +77,7 @@
         <CheckBox
             android:id="@+id/cb_interest_region_select_btn3"
             android:layout_width="75dp"
-            android:layout_height="32dp"
+            android:layout_height="35dp"
             android:background="@drawable/selector_custom_region_checkbox"
             android:button="@null"
             android:gravity="center"
@@ -93,7 +93,7 @@
         <CheckBox
             android:id="@+id/cb_interest_region_select_btn4"
             android:layout_width="75dp"
-            android:layout_height="32dp"
+            android:layout_height="35dp"
             android:background="@drawable/selector_custom_region_checkbox"
             android:button="@null"
             android:gravity="center"
@@ -109,7 +109,7 @@
         <CheckBox
             android:id="@+id/cb_interest_region_select_btn5"
             android:layout_width="75dp"
-            android:layout_height="32dp"
+            android:layout_height="35dp"
             android:layout_marginTop="16dp"
             android:background="@drawable/selector_custom_region_checkbox"
             android:button="@null"
@@ -126,7 +126,7 @@
         <CheckBox
             android:id="@+id/cb_interest_region_select_btn6"
             android:layout_width="75dp"
-            android:layout_height="32dp"
+            android:layout_height="35dp"
             android:background="@drawable/selector_custom_region_checkbox"
             android:button="@null"
             android:gravity="center"
@@ -142,7 +142,7 @@
         <CheckBox
             android:id="@+id/cb_interest_region_select_btn7"
             android:layout_width="75dp"
-            android:layout_height="32dp"
+            android:layout_height="35dp"
             android:background="@drawable/selector_custom_region_checkbox"
             android:button="@null"
             android:gravity="center"
@@ -158,7 +158,7 @@
         <CheckBox
             android:id="@+id/cb_interest_region_select_btn8"
             android:layout_width="75dp"
-            android:layout_height="32dp"
+            android:layout_height="35dp"
             android:background="@drawable/selector_custom_region_checkbox"
             android:button="@null"
             android:gravity="center"
@@ -174,7 +174,7 @@
         <CheckBox
             android:id="@+id/cb_interest_region_select_btn9"
             android:layout_width="75dp"
-            android:layout_height="32dp"
+            android:layout_height="35dp"
             android:layout_marginTop="16dp"
             android:background="@drawable/selector_custom_region_checkbox"
             android:button="@null"
@@ -191,7 +191,7 @@
         <CheckBox
             android:id="@+id/cb_interest_region_select_btn10"
             android:layout_width="75dp"
-            android:layout_height="32dp"
+            android:layout_height="35dp"
             android:background="@drawable/selector_custom_region_checkbox"
             android:button="@null"
             android:gravity="center"
@@ -207,7 +207,7 @@
         <CheckBox
             android:id="@+id/cb_interest_region_select_btn11"
             android:layout_width="75dp"
-            android:layout_height="32dp"
+            android:layout_height="35dp"
             android:background="@drawable/selector_custom_region_checkbox"
             android:button="@null"
             android:gravity="center"
@@ -223,7 +223,7 @@
         <CheckBox
             android:id="@+id/cb_interest_region_select_btn12"
             android:layout_width="75dp"
-            android:layout_height="32dp"
+            android:layout_height="35dp"
             android:background="@drawable/selector_custom_region_checkbox"
             android:button="@null"
             android:gravity="center"
@@ -239,7 +239,7 @@
         <CheckBox
             android:id="@+id/cb_interest_region_select_btn13"
             android:layout_width="75dp"
-            android:layout_height="32dp"
+            android:layout_height="35dp"
             android:layout_marginTop="16dp"
             android:background="@drawable/selector_custom_region_checkbox"
             android:button="@null"
@@ -256,7 +256,7 @@
         <CheckBox
             android:id="@+id/cb_interest_region_select_btn14"
             android:layout_width="75dp"
-            android:layout_height="32dp"
+            android:layout_height="35dp"
             android:background="@drawable/selector_custom_region_checkbox"
             android:button="@null"
             android:gravity="center"
@@ -272,7 +272,7 @@
         <CheckBox
             android:id="@+id/cb_interest_region_select_btn15"
             android:layout_width="75dp"
-            android:layout_height="32dp"
+            android:layout_height="35dp"
             android:background="@drawable/selector_custom_region_checkbox"
             android:button="@null"
             android:gravity="center"
@@ -288,7 +288,7 @@
         <CheckBox
             android:id="@+id/cb_interest_region_select_btn16"
             android:layout_width="75dp"
-            android:layout_height="32dp"
+            android:layout_height="35dp"
             android:background="@drawable/selector_custom_region_checkbox"
             android:button="@null"
             android:gravity="center"
@@ -304,7 +304,7 @@
         <CheckBox
             android:id="@+id/cb_interest_region_select_btn17"
             android:layout_width="75dp"
-            android:layout_height="32dp"
+            android:layout_height="35dp"
             android:layout_marginTop="16dp"
             android:background="@drawable/selector_custom_region_checkbox"
             android:button="@null"
@@ -321,7 +321,7 @@
         <CheckBox
             android:id="@+id/cb_interest_region_select_btn18"
             android:layout_width="75dp"
-            android:layout_height="32dp"
+            android:layout_height="35dp"
             android:background="@drawable/selector_custom_region_checkbox"
             android:button="@null"
             android:gravity="center"
@@ -337,7 +337,7 @@
         <CheckBox
             android:id="@+id/cb_interest_region_select_btn19"
             android:layout_width="75dp"
-            android:layout_height="32dp"
+            android:layout_height="35dp"
             android:background="@drawable/selector_custom_region_checkbox"
             android:button="@null"
             android:gravity="center"
@@ -353,7 +353,7 @@
         <CheckBox
             android:id="@+id/cb_interest_region_select_btn20"
             android:layout_width="75dp"
-            android:layout_height="32dp"
+            android:layout_height="35dp"
             android:background="@drawable/selector_custom_region_checkbox"
             android:button="@null"
             android:gravity="center"
@@ -369,7 +369,7 @@
         <CheckBox
             android:id="@+id/cb_interest_region_select_btn21"
             android:layout_width="75dp"
-            android:layout_height="32dp"
+            android:layout_height="35dp"
             android:layout_marginTop="16dp"
             android:background="@drawable/selector_custom_region_checkbox"
             android:button="@null"
@@ -386,7 +386,7 @@
         <CheckBox
             android:id="@+id/cb_interest_region_select_btn22"
             android:layout_width="75dp"
-            android:layout_height="32dp"
+            android:layout_height="35dp"
             android:background="@drawable/selector_custom_region_checkbox"
             android:button="@null"
             android:gravity="center"
@@ -402,7 +402,7 @@
         <CheckBox
             android:id="@+id/cb_interest_region_select_btn23"
             android:layout_width="75dp"
-            android:layout_height="32dp"
+            android:layout_height="35dp"
             android:background="@drawable/selector_custom_region_checkbox"
             android:button="@null"
             android:gravity="center"
@@ -418,7 +418,7 @@
         <CheckBox
             android:id="@+id/cb_interest_region_select_btn24"
             android:layout_width="75dp"
-            android:layout_height="32dp"
+            android:layout_height="35dp"
             android:background="@drawable/selector_custom_region_checkbox"
             android:button="@null"
             android:gravity="center"
@@ -434,7 +434,7 @@
         <CheckBox
             android:id="@+id/cb_interest_region_select_btn25"
             android:layout_width="75dp"
-            android:layout_height="32dp"
+            android:layout_height="35dp"
             android:layout_marginTop="16dp"
             android:layout_marginBottom="10dp"
             android:background="@drawable/selector_custom_region_checkbox"
@@ -451,10 +451,11 @@
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <ImageView
-        android:layout_width="200dp"
-        android:layout_height="200dp"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         android:src="@drawable/img_seoul"
         app:layout_constraintBottom_toTopOf="@+id/textView"
+        app:layout_constraintDimensionRatio="1:1"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/constraintLayout" />
@@ -475,9 +476,9 @@
     <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/btn_interest_region_select_okay"
         android:layout_width="match_parent"
-        android:layout_height="35dp"
-        android:layout_marginBottom="15dp"
+        android:layout_height="45dp"
         android:layout_marginHorizontal="20dp"
+        android:layout_marginBottom="15dp"
         android:background="@drawable/selector_okay_button"
         android:enabled="false"
         android:text="확인"

--- a/app/src/main/res/layout/fragment_filter.xml
+++ b/app/src/main/res/layout/fragment_filter.xml
@@ -52,7 +52,7 @@
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="wrap_content">
 
             <TextView
                 android:id="@+id/tv_filter_title1"
@@ -66,713 +66,801 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <TextView
-                android:id="@+id/tv_filter_title1_header1"
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/cl_filter_title1_header1"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="20dp"
-                android:layout_marginTop="12dp"
-                android:text="체육시설"
-                android:textColor="@color/black"
-                android:textSize="16sp"
-                android:textStyle="bold"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/tv_filter_title1" />
+                app:layout_constraintTop_toBottomOf="@+id/tv_filter_title1">
 
-            <ImageView
-                android:id="@+id/iv_filter_title1_header1_btn"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="20dp"
-                android:src="@drawable/ic_more"
-                app:layout_constraintBottom_toBottomOf="@+id/tv_filter_title1_header1"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/tv_filter_title1_header1" />
+                <TextView
+                    android:id="@+id/tv_filter_title1_header1"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="20dp"
+                    android:layout_marginTop="12dp"
+                    android:text="체육시설"
+                    android:textColor="@color/black"
+                    android:textSize="16sp"
+                    android:textStyle="bold"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
 
-            <com.google.android.material.divider.MaterialDivider
-                android:id="@+id/divider_filter_title1_header1"
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:layout_marginHorizontal="20dp"
-                android:layout_marginTop="8dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/tv_filter_title1_header1" />
-
-            <com.google.android.material.chip.ChipGroup
-                android:id="@+id/cg_filter_title1_header1"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="20dp"
-                android:layout_marginTop="10dp"
-                android:visibility="gone"
-                app:chipSpacingHorizontal="8dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/divider_filter_title1_header1">
-
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_1_1"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
+                <ImageView
+                    android:id="@+id/iv_filter_title1_header1_btn"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="축구장"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                    android:layout_marginEnd="20dp"
+                    android:src="@drawable/ic_more"
+                    app:layout_constraintBottom_toBottomOf="@+id/tv_filter_title1_header1"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="@+id/tv_filter_title1_header1" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_1_2"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
+                <com.google.android.material.divider.MaterialDivider
+                    android:id="@+id/divider_filter_title1_header1"
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:layout_marginHorizontal="20dp"
+                    android:layout_marginTop="8dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/tv_filter_title1_header1" />
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="테니스장"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/divider_filter_title1_header1">
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_1_3"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="탁구장"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                    <com.google.android.material.chip.ChipGroup
+                        android:id="@+id/cg_filter_title1_header1"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginHorizontal="20dp"
+                        android:layout_marginTop="10dp"
+                        android:animateLayoutChanges="true"
+                        android:visibility="gone"
+                        app:chipSpacingHorizontal="8dp"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent">
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_1_4"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="골프장"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_1_1"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="축구장"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_1_5"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="야구장"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_1_2"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="테니스장"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_1_6"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="배구장"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_1_3"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="탁구장"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_1_7"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="족구장"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_1_4"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="골프장"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_1_8"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="풋살장"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_1_5"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="야구장"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_1_9"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="배드민턴장"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_1_6"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="배구장"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_1_10"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="다목적경기장"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_1_7"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="족구장"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_1_11"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="체육관"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_1_8"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="풋살장"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_1_12"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="농구장"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
-            </com.google.android.material.chip.ChipGroup>
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_1_9"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="배드민턴장"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-            <TextView
-                android:id="@+id/tv_filter_title1_header2"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="20dp"
-                android:layout_marginTop="12dp"
-                android:text="교육"
-                android:textColor="@color/black"
-                android:textSize="16sp"
-                android:textStyle="bold"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/cg_filter_title1_header1" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_1_10"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="다목적경기장"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-            <ImageView
-                android:id="@+id/iv_filter_title1_header2_btn"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="20dp"
-                android:src="@drawable/ic_more"
-                app:layout_constraintBottom_toBottomOf="@+id/tv_filter_title1_header2"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/tv_filter_title1_header2" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_1_11"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="체육관"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-            <com.google.android.material.divider.MaterialDivider
-                android:id="@+id/divider_filter_title1_header2"
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:layout_marginHorizontal="20dp"
-                android:layout_marginTop="8dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/tv_filter_title1_header2" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_1_12"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="농구장"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
+                    </com.google.android.material.chip.ChipGroup>
+                </androidx.constraintlayout.widget.ConstraintLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
-            <com.google.android.material.chip.ChipGroup
-                android:id="@+id/cg_filter_title1_header2"
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/cl_filter_title1_header2"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginHorizontal="20dp"
-                android:layout_marginTop="10dp"
-                android:visibility="gone"
-                app:chipSpacingHorizontal="8dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/divider_filter_title1_header2">
+                app:layout_constraintTop_toBottomOf="@+id/cl_filter_title1_header1">
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_2_1"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
+                <TextView
+                    android:id="@+id/tv_filter_title1_header2"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="20dp"
+                    android:layout_marginTop="12dp"
+                    android:text="교육"
+                    android:textColor="@color/black"
+                    android:textSize="16sp"
+                    android:textStyle="bold"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <ImageView
+                    android:id="@+id/iv_filter_title1_header2_btn"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="교양/어학"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                    android:layout_marginEnd="20dp"
+                    android:src="@drawable/ic_more"
+                    app:layout_constraintBottom_toBottomOf="@+id/tv_filter_title1_header2"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="@+id/tv_filter_title1_header2" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_2_2"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
+                <com.google.android.material.divider.MaterialDivider
+                    android:id="@+id/divider_filter_title1_header2"
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:layout_marginHorizontal="20dp"
+                    android:layout_marginTop="8dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/tv_filter_title1_header2" />
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="정보통신"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/divider_filter_title1_header2">
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_2_3"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="역사"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                    <com.google.android.material.chip.ChipGroup
+                        android:id="@+id/cg_filter_title1_header2"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginHorizontal="20dp"
+                        android:layout_marginTop="10dp"
+                        android:animateLayoutChanges="true"
+                        android:visibility="gone"
+                        app:chipSpacingHorizontal="8dp"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent">
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_2_4"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="자연과학"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_2_1"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="교양/어학"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_2_5"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="도시농업"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_2_2"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="정보통신"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_2_6"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="청년정보"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_2_3"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="역사"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_2_7"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="스포츠"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_2_4"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="자연과학"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_2_8"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="미술제작"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_2_5"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="도시농업"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_2_9"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="공예/취미"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_2_6"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="청년정보"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_2_10"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="전문/자격증"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_2_7"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="스포츠"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_2_11"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="기타"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
-            </com.google.android.material.chip.ChipGroup>
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_2_8"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="미술제작"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-            <TextView
-                android:id="@+id/tv_filter_title1_header3"
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_2_9"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="공예/취미"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
+
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_2_10"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="전문/자격증"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
+
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_2_11"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="기타"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
+                    </com.google.android.material.chip.ChipGroup>
+                </androidx.constraintlayout.widget.ConstraintLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/cl_filter_title1_header3"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="20dp"
-                android:layout_marginTop="12dp"
-                android:text="문화행사"
-                android:textColor="@color/black"
-                android:textSize="16sp"
-                android:textStyle="bold"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/cg_filter_title1_header2" />
+                app:layout_constraintTop_toBottomOf="@+id/cl_filter_title1_header2">
 
-            <ImageView
-                android:id="@+id/iv_filter_title1_header3_btn"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="20dp"
-                android:src="@drawable/ic_more"
-                app:layout_constraintBottom_toBottomOf="@+id/tv_filter_title1_header3"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/tv_filter_title1_header3" />
-
-            <com.google.android.material.divider.MaterialDivider
-                android:id="@+id/divider_filter_title1_header3"
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:layout_marginHorizontal="20dp"
-                android:layout_marginTop="8dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/tv_filter_title1_header3" />
-
-            <com.google.android.material.chip.ChipGroup
-                android:id="@+id/cg_filter_title1_header3"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="20dp"
-                android:layout_marginTop="10dp"
-                android:visibility="gone"
-                app:chipSpacingHorizontal="8dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/divider_filter_title1_header3">
-
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_3_1"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
+                <TextView
+                    android:id="@+id/tv_filter_title1_header3"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="전시/관람"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
-
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_3_2"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="교육체험"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
-
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_3_3"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
+                    android:layout_marginStart="20dp"
+                    android:layout_marginTop="12dp"
                     android:text="문화행사"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                    android:textColor="@color/black"
+                    android:textSize="16sp"
+                    android:textStyle="bold"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_3_4"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
+                <ImageView
+                    android:id="@+id/iv_filter_title1_header3_btn"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="산림여가"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                    android:layout_marginEnd="20dp"
+                    android:src="@drawable/ic_more"
+                    app:layout_constraintBottom_toBottomOf="@+id/tv_filter_title1_header3"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="@+id/tv_filter_title1_header3" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_3_5"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
+                <com.google.android.material.divider.MaterialDivider
+                    android:id="@+id/divider_filter_title1_header3"
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:layout_marginHorizontal="20dp"
+                    android:layout_marginTop="8dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/tv_filter_title1_header3" />
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="공원탐방"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/divider_filter_title1_header3">
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_3_6"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="서울형키즈카페"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                    <com.google.android.material.chip.ChipGroup
+                        android:id="@+id/cg_filter_title1_header3"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginHorizontal="20dp"
+                        android:layout_marginTop="10dp"
+                        android:animateLayoutChanges="true"
+                        android:visibility="gone"
+                        app:chipSpacingHorizontal="8dp"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent">
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_3_7"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="농장체험"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
-            </com.google.android.material.chip.ChipGroup>
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_3_1"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="전시/관람"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-            <TextView
-                android:id="@+id/tv_filter_title1_header4"
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_3_2"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="교육체험"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
+
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_3_3"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="문화행사"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
+
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_3_4"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="산림여가"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
+
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_3_5"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="공원탐방"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
+
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_3_6"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="서울형키즈카페"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
+
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_3_7"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="농장체험"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
+                    </com.google.android.material.chip.ChipGroup>
+                </androidx.constraintlayout.widget.ConstraintLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/cl_filter_title1_header4"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="20dp"
-                android:layout_marginTop="12dp"
-                android:text="시설대관"
-                android:textColor="@color/black"
-                android:textSize="16sp"
-                android:textStyle="bold"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/cg_filter_title1_header3" />
+                app:layout_constraintTop_toBottomOf="@+id/cl_filter_title1_header3">
 
-            <ImageView
-                android:id="@+id/iv_filter_title1_header4_btn"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="20dp"
-                android:src="@drawable/ic_more"
-                app:layout_constraintBottom_toBottomOf="@+id/tv_filter_title1_header4"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/tv_filter_title1_header4" />
+                <TextView
+                    android:id="@+id/tv_filter_title1_header4"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="20dp"
+                    android:layout_marginTop="12dp"
+                    android:text="시설대관"
+                    android:textColor="@color/black"
+                    android:textSize="16sp"
+                    android:textStyle="bold"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
 
-            <com.google.android.material.divider.MaterialDivider
-                android:id="@+id/divider_filter_title1_header4"
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:layout_marginHorizontal="20dp"
-                android:layout_marginTop="8dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/tv_filter_title1_header4" />
-
-            <com.google.android.material.chip.ChipGroup
-                android:id="@+id/cg_filter_title1_header4"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="20dp"
-                android:layout_marginTop="10dp"
-                android:visibility="gone"
-                app:chipSpacingHorizontal="8dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/divider_filter_title1_header4">
-
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_4_1"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
+                <ImageView
+                    android:id="@+id/iv_filter_title1_header4_btn"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="다목적실"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                    android:layout_marginEnd="20dp"
+                    android:src="@drawable/ic_more"
+                    app:layout_constraintBottom_toBottomOf="@+id/tv_filter_title1_header4"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="@+id/tv_filter_title1_header4" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_4_2"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
+                <com.google.android.material.divider.MaterialDivider
+                    android:id="@+id/divider_filter_title1_header4"
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:layout_marginHorizontal="20dp"
+                    android:layout_marginTop="8dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/tv_filter_title1_header4" />
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="공연장"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/divider_filter_title1_header4">
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_4_3"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="강당"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                    <com.google.android.material.chip.ChipGroup
+                        android:id="@+id/cg_filter_title1_header4"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginHorizontal="20dp"
+                        android:layout_marginTop="10dp"
+                        android:visibility="gone"
+                        app:chipSpacingHorizontal="8dp"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent">
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_4_4"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="주민공유공간"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_4_1"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="다목적실"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_4_5"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="캠핑장"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_4_2"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="공연장"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_4_6"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="청년공간"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_4_3"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="강당"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_4_7"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="녹화장소"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_4_4"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="주민공유공간"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_4_8"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="회의실"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_4_5"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="캠핑장"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_4_9"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="강의실"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_4_6"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="청년공간"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_4_10"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="민원/기타"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
-            </com.google.android.material.chip.ChipGroup>
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_4_7"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="녹화장소"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-            <TextView
-                android:id="@+id/tv_filter_title1_header5"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="20dp"
-                android:layout_marginTop="12dp"
-                android:text="진료"
-                android:textColor="@color/black"
-                android:textSize="16sp"
-                android:textStyle="bold"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/cg_filter_title1_header4" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_4_8"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="회의실"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-            <ImageView
-                android:id="@+id/iv_filter_title1_header5_btn"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="20dp"
-                android:src="@drawable/ic_more"
-                app:layout_constraintBottom_toBottomOf="@+id/tv_filter_title1_header5"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/tv_filter_title1_header5" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_4_9"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="강의실"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-            <com.google.android.material.divider.MaterialDivider
-                android:id="@+id/divider_filter_title1_header5"
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:layout_marginHorizontal="20dp"
-                android:layout_marginTop="8dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/tv_filter_title1_header5" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_4_10"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="민원/기타"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
+                    </com.google.android.material.chip.ChipGroup>
+                </androidx.constraintlayout.widget.ConstraintLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
-            <com.google.android.material.chip.ChipGroup
-                android:id="@+id/cg_filter_title1_header5"
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/cl_filter_title1_header5"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginHorizontal="20dp"
-                android:layout_marginTop="10dp"
-                android:visibility="gone"
-                app:chipSpacingHorizontal="8dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/divider_filter_title1_header5">
+                app:layout_constraintTop_toBottomOf="@+id/cl_filter_title1_header4">
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_5_1"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
+                <TextView
+                    android:id="@+id/tv_filter_title1_header5"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="20dp"
+                    android:layout_marginTop="12dp"
+                    android:text="진료"
+                    android:textColor="@color/black"
+                    android:textSize="16sp"
+                    android:textStyle="bold"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <ImageView
+                    android:id="@+id/iv_filter_title1_header5_btn"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="병원"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                    android:layout_marginEnd="20dp"
+                    android:src="@drawable/ic_more"
+                    app:layout_constraintBottom_toBottomOf="@+id/tv_filter_title1_header5"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="@+id/tv_filter_title1_header5" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_5_2"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="어린이병원"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                <com.google.android.material.divider.MaterialDivider
+                    android:id="@+id/divider_filter_title1_header5"
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:layout_marginHorizontal="20dp"
+                    android:layout_marginTop="8dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/tv_filter_title1_header5" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_1_5_3"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="장애인버스"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
-            </com.google.android.material.chip.ChipGroup>
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/divider_filter_title1_header5">
+
+                    <com.google.android.material.chip.ChipGroup
+                        android:id="@+id/cg_filter_title1_header5"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginHorizontal="20dp"
+                        android:layout_marginTop="10dp"
+                        android:visibility="gone"
+                        app:chipSpacingHorizontal="8dp"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent">
+
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_5_1"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="병원"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
+
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_5_2"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="어린이병원"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
+
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_1_5_3"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="장애인버스"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
+                    </com.google.android.material.chip.ChipGroup>
+                </androidx.constraintlayout.widget.ConstraintLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
             <TextView
                 android:id="@+id/tv_filter_title2"
@@ -785,329 +873,346 @@
                 android:textSize="18sp"
                 android:textStyle="bold"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/cg_filter_title1_header5" />
+                app:layout_constraintTop_toBottomOf="@+id/cl_filter_title1_header5" />
 
-            <TextView
-                android:id="@+id/tv_filter_title2_header1"
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/cl_filter_title2_header1"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="20dp"
-                android:layout_marginTop="12dp"
-                android:text="서울시"
-                android:textColor="@color/black"
-                android:textSize="16sp"
-                android:textStyle="bold"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/tv_filter_title2" />
+                app:layout_constraintTop_toBottomOf="@+id/tv_filter_title2">
 
-            <ImageView
-                android:id="@+id/iv_filter_title2_header1_btn"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="20dp"
-                android:src="@drawable/ic_more"
-                app:layout_constraintBottom_toBottomOf="@+id/tv_filter_title2_header1"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/tv_filter_title2_header1" />
+                <TextView
+                    android:id="@+id/tv_filter_title2_header1"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="20dp"
+                    android:layout_marginTop="12dp"
+                    android:text="서울시"
+                    android:textColor="@color/black"
+                    android:textSize="16sp"
+                    android:textStyle="bold"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
 
-            <com.google.android.material.divider.MaterialDivider
-                android:id="@+id/divider_filter_title2_header1"
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:layout_marginHorizontal="20dp"
-                android:layout_marginTop="8dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/tv_filter_title2_header1" />
-
-            <com.google.android.material.chip.ChipGroup
-                android:id="@+id/cg_filter_title2_header1"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="20dp"
-                android:layout_marginTop="10dp"
-                android:visibility="gone"
-                app:chipSpacingHorizontal="8dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/divider_filter_title2_header1">
-
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_2_1_1"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
+                <ImageView
+                    android:id="@+id/iv_filter_title2_header1_btn"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="강남구"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                    android:layout_marginEnd="20dp"
+                    android:src="@drawable/ic_more"
+                    app:layout_constraintBottom_toBottomOf="@+id/tv_filter_title2_header1"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="@+id/tv_filter_title2_header1" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_2_1_2"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="강동구"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                <com.google.android.material.divider.MaterialDivider
+                    android:id="@+id/divider_filter_title2_header1"
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:layout_marginHorizontal="20dp"
+                    android:layout_marginTop="8dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/tv_filter_title2_header1" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_2_1_3"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="강북구"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/divider_filter_title2_header1">
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_2_1_4"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="강서구"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                    <com.google.android.material.chip.ChipGroup
+                        android:id="@+id/cg_filter_title2_header1"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginHorizontal="20dp"
+                        android:layout_marginTop="10dp"
+                        android:visibility="gone"
+                        app:chipSpacingHorizontal="8dp"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent">
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_2_1_5"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="관악구"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_2_1_1"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="강남구"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_2_1_6"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="광진구"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_2_1_2"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="강동구"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_2_1_7"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="구로구"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_2_1_3"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="강북구"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_2_1_8"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="금천구"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_2_1_4"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="강서구"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_2_1_9"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="노원구"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_2_1_5"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="관악구"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_2_1_10"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="도봉구"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_2_1_6"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="광진구"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_2_1_11"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="동대문구"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_2_1_7"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="구로구"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_2_1_12"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="동작구"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_2_1_8"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="금천구"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_2_1_13"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="마포구"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_2_1_9"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="노원구"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_2_1_14"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="서대문구"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_2_1_10"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="도봉구"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_2_1_15"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="서초구"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_2_1_11"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="동대문구"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_2_1_16"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="성동구"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_2_1_12"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="동작구"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_2_1_17"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="성북구"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_2_1_13"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="마포구"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_2_1_18"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="송파구"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_2_1_14"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="서대문구"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_2_1_19"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="양천구"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_2_1_15"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="서초구"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_2_1_20"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="영등포구"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_2_1_16"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="성동구"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_2_1_21"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="용산구"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_2_1_17"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="성북구"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_2_1_22"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="은평구"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_2_1_18"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="송파구"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_2_1_23"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="종로구"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_2_1_19"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="양천구"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_2_1_24"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="중구"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_2_1_20"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="영등포구"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
 
-                <com.google.android.material.chip.Chip
-                    android:id="@+id/chip_2_1_25"
-                    style="@style/Widget.MaterialComponents.Chip.Choice"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="중랑구"
-                    android:textColor="@color/selector_chip_button_text"
-                    android:textSize="14sp"
-                    app:chipBackgroundColor="@color/selector_chip_button"
-                    app:chipMinHeight="36dp" />
-            </com.google.android.material.chip.ChipGroup>
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_2_1_21"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="용산구"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
+
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_2_1_22"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="은평구"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
+
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_2_1_23"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="종로구"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
+
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_2_1_24"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="중구"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
+
+                        <com.google.android.material.chip.Chip
+                            android:id="@+id/chip_2_1_25"
+                            style="@style/Widget.MaterialComponents.Chip.Choice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="중랑구"
+                            android:textColor="@color/selector_chip_button_text"
+                            android:textSize="14sp"
+                            app:chipBackgroundColor="@color/selector_chip_button"
+                            app:chipMinHeight="36dp" />
+                    </com.google.android.material.chip.ChipGroup>
+                </androidx.constraintlayout.widget.ConstraintLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
             <TextView
                 android:id="@+id/tv_filter_title3"
@@ -1120,7 +1225,7 @@
                 android:textSize="18sp"
                 android:textStyle="bold"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/cg_filter_title2_header1" />
+                app:layout_constraintTop_toBottomOf="@+id/cl_filter_title2_header1" />
 
             <com.google.android.material.chip.ChipGroup
                 android:id="@+id/cg_filter_title3_header1"


### PR DESCRIPTION
## PR 체크리스트
다음 요구사항을 충족하는지 확인해주세요

- [x] 커밋메세지 규칙을 따릅니다.

## PR 유형
어떤 변경사항이 있는지 모두 체크해 주세요

- [x] 기능구현
- [ ] 버그픽스
- [ ] 리팩토링
- [ ] 문서 변경
- [x] 레이아웃
- [ ] 기타

## 변경사항 작성
<!-- 변경사항의 상세 정보를 작성해주세요. -->

-기능
필터 옵션들이 슬라이드 애니메이션을 하면서 나타나고 사라짐
-설명
Animation 활용

필터 레이아웃 xml에서 뷰들을 크게 크게 ConstraintLayout으로 묶고 ChipGroup 안에는 animateLayoutChanges 속성을 true로 줌 

slide_down.xml, slide_up.xml 파일을 만들고 AnimationUtils.loadAnimation에 넣고 startAnimation 실행시킴 나타나는 건 잘 나타나는데 리스너를 달지 않는 이상 사라지는 건 의도대로 되지는 않음
그런데 생각해보면 기다리는 걸 기다리는 게 사용자 입장에서는 더 별로이지 않을까 싶어 관련된 코드를 그냥 주석처리해놓음(바로 바꿀 수 있게) 
아직 안 되는 유일한 거는 아래의 뷰들이 자연스럽게 움직이는 것이다...

## Merge 후 브랜치 삭제 여부
- [ ] 반영된 브랜치 삭제