### PR TITLE
[ Feat & Refactor ] : 지도페이지 기능 추가

### DIFF
--- a/app/src/main/java/com/example/seoulpublicservice/SeoulPublicServiceApplication.kt
+++ b/app/src/main/java/com/example/seoulpublicservice/SeoulPublicServiceApplication.kt
@@ -38,7 +38,6 @@ class SeoulPublicServiceApplication : Application() {
         _container = DefaultAppContainer(this) { rowList }
 
         CoroutineScope(Dispatchers.Default).launch {
-            Looper.prepare()
             updateRowList()
             _initialLoadingFinished.postValue(true)
         }
@@ -52,6 +51,7 @@ class SeoulPublicServiceApplication : Application() {
             (cap.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) ||
                     cap.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)).not()
         ) {
+            Looper.prepare()
             Toast.makeText(
                 this,
                 "네트워크 연결이 불가능하므로 저장된 데이터로 표시됩니다.",
@@ -100,6 +100,7 @@ class SeoulPublicServiceApplication : Application() {
             }
         } catch (e: Throwable) {
             Log.e("jj-앱클래스", "데이터 통신 에러: $e")
+            Looper.prepare()
             Toast.makeText(
                 this,
                 "데이터를 받아오는 과정에서 문제가 발생했습니다. 저장된 데이터로 표시됩니다.",

--- a/app/src/main/java/com/example/seoulpublicservice/ui/map/MapDetailInfoAdapter.kt
+++ b/app/src/main/java/com/example/seoulpublicservice/ui/map/MapDetailInfoAdapter.kt
@@ -12,6 +12,7 @@ import com.example.seoulpublicservice.R
 import com.example.seoulpublicservice.databinding.ItemMapInfoWindowBinding
 import com.example.seoulpublicservice.pref.SavedPrefRepository
 import com.example.seoulpublicservice.seoul.Row
+import com.example.seoulpublicservice.util.loadWithHolder
 
 class MapDetailInfoAdapter(
     private val saveService: (String) -> Unit,
@@ -89,7 +90,7 @@ class MapDetailInfoAdapter(
             } else {
                 ivMapInfoSaveServiceBtn.setImageResource(R.drawable.ic_save_empty)
             }
-            ivMapInfoPicture.load(item.imgurl)
+            ivMapInfoPicture.loadWithHolder(item.imgurl)
             tvMapInfoRegion.text = item.areanm
             tvMapInfoService.text =
                 HtmlCompat.fromHtml(item.svcnm, HtmlCompat.FROM_HTML_MODE_LEGACY)

--- a/app/src/main/java/com/example/seoulpublicservice/ui/map/MapDetailInfoAdapter.kt
+++ b/app/src/main/java/com/example/seoulpublicservice/ui/map/MapDetailInfoAdapter.kt
@@ -8,13 +8,17 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import coil.load
+import com.example.seoulpublicservice.R
 import com.example.seoulpublicservice.databinding.ItemMapInfoWindowBinding
+import com.example.seoulpublicservice.pref.SavedPrefRepository
 import com.example.seoulpublicservice.seoul.Row
 
 class MapDetailInfoAdapter(
+    private val saveService: (String) -> Unit,
     private val moveReservationPage: (String) -> Unit,
     private val shareUrl: (String) -> Unit,
-    private val moveDetailPage: (String) -> Unit
+    private val moveDetailPage: (String) -> Unit,
+    private val savedPrefRepository: SavedPrefRepository
 ) : ListAdapter<Row, MapDetailInfoAdapter.InfoViewHolder>(object : DiffUtil.ItemCallback<Row>() {
     override fun areItemsTheSame(oldItem: Row, newItem: Row): Boolean {
         return oldItem.svcid == newItem.svcid
@@ -47,9 +51,11 @@ class MapDetailInfoAdapter(
                         parent,
                         false
                     ),
+                    saveService = saveService,
                     moveReservationPage = moveReservationPage,
                     shareUrl = shareUrl,
-                    moveDetailPage = moveDetailPage
+                    moveDetailPage = moveDetailPage,
+                    savedPrefRepository = savedPrefRepository
                 )
             }
 
@@ -71,11 +77,18 @@ class MapDetailInfoAdapter(
 
     class DetailInfoViewHolder(
         private val binding: ItemMapInfoWindowBinding,
+        private val saveService: (String) -> Unit,
         private val moveReservationPage: (String) -> Unit,
         private val shareUrl: (String) -> Unit,
-        private val moveDetailPage: (String) -> Unit
+        private val moveDetailPage: (String) -> Unit,
+        private val savedPrefRepository: SavedPrefRepository
     ) : InfoViewHolder(binding.root) {
         override fun onBind(item: Row) = with(binding) {
+            if (savedPrefRepository.savedSvcidListLiveData.value.orEmpty().contains(item.svcid)) {
+                ivMapInfoSaveServiceBtn.setImageResource(R.drawable.ic_save_fill)
+            } else {
+                ivMapInfoSaveServiceBtn.setImageResource(R.drawable.ic_save_empty)
+            }
             ivMapInfoPicture.load(item.imgurl)
             tvMapInfoRegion.text = item.areanm
             tvMapInfoService.text =
@@ -103,6 +116,15 @@ class MapDetailInfoAdapter(
 
                 else -> {
                     false
+                }
+            }
+
+            binding.ivMapInfoSaveServiceBtn.setOnClickListener {
+                saveService(item.svcid)
+                if (savedPrefRepository.savedSvcidListLiveData.value.orEmpty().contains(item.svcid)) {
+                    ivMapInfoSaveServiceBtn.setImageResource(R.drawable.ic_save_fill)
+                } else {
+                    ivMapInfoSaveServiceBtn.setImageResource(R.drawable.ic_save_empty)
                 }
             }
 

--- a/app/src/main/java/com/example/seoulpublicservice/ui/map/MapFragment.kt
+++ b/app/src/main/java/com/example/seoulpublicservice/ui/map/MapFragment.kt
@@ -12,6 +12,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.viewpager2.widget.ViewPager2.OnPageChangeCallback
 import com.example.seoulpublicservice.R
+import com.example.seoulpublicservice.SeoulPublicServiceApplication
 import com.example.seoulpublicservice.databinding.FragmentMapBinding
 import com.example.seoulpublicservice.dialog.filter.FilterFragment
 import com.naver.maps.geometry.LatLng
@@ -35,10 +36,24 @@ class MapFragment : Fragment(), OnMapReadyCallback {
     private lateinit var naverMap: NaverMap
     private lateinit var locationSource: FusedLocationSource
 
+    private val app by lazy {
+        requireActivity().application as SeoulPublicServiceApplication
+    }
+    private val container by lazy {
+        app.container
+    }
+
     private val activeMarkers: MutableList<Marker> = mutableListOf()
+
+    private val rvAdapter: MapOptionAdapter by lazy {
+        MapOptionAdapter()
+    }
 
     private val adapter: MapDetailInfoAdapter by lazy {
         MapDetailInfoAdapter(
+            saveService = { id ->
+                viewModel.saveService(id)
+            },
             moveReservationPage = { url ->
                 viewModel.moveReservationPage(url)
             },
@@ -47,7 +62,8 @@ class MapFragment : Fragment(), OnMapReadyCallback {
             },
             moveDetailPage = { id ->
                 viewModel.moveDetailPage(id)
-            }
+            },
+            savedPrefRepository = container.savedPrefRepository
         )
     }
 
@@ -81,10 +97,14 @@ class MapFragment : Fragment(), OnMapReadyCallback {
         binding.vpMapDetailInfo.registerOnPageChangeCallback(object : OnPageChangeCallback() {})
         binding.vpMapDetailInfo.offscreenPageLimit = 1
 
+        binding.rvMapSelectedOption.adapter = rvAdapter
+        rvAdapter.submitList(app.container.filterPrefRepository.load().flatten())
+
         binding.tvMapFilterBtn.setOnClickListener {
             val dialog = FilterFragment.newInstance(
                 onClickButton = {
                     viewModel.loadSavedOptions()
+                    rvAdapter.submitList(app.container.filterPrefRepository.load().flatten())
                 }
             )
             dialog.show(requireActivity().supportFragmentManager, "FilterFragment")

--- a/app/src/main/java/com/example/seoulpublicservice/ui/map/MapOptionAdapter.kt
+++ b/app/src/main/java/com/example/seoulpublicservice/ui/map/MapOptionAdapter.kt
@@ -1,0 +1,46 @@
+package com.example.seoulpublicservice.ui.map
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.example.seoulpublicservice.databinding.ItemSelectedOptionBinding
+
+class MapOptionAdapter : ListAdapter<String, MapOptionAdapter.OptionViewHolder>(object :
+    DiffUtil.ItemCallback<String>() {
+    override fun areItemsTheSame(oldItem: String, newItem: String): Boolean {
+        return oldItem === newItem
+    }
+
+    override fun areContentsTheSame(oldItem: String, newItem: String): Boolean {
+        return oldItem == newItem
+    }
+
+}) {
+    abstract class OptionViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        abstract fun onBind(item: String)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): OptionViewHolder {
+        return SelectedOptionViewHolder(
+            binding = ItemSelectedOptionBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        )
+    }
+
+    override fun onBindViewHolder(holder: OptionViewHolder, position: Int) {
+        holder.onBind(getItem(position))
+    }
+
+    class SelectedOptionViewHolder(private val binding: ItemSelectedOptionBinding) :
+        OptionViewHolder(binding.root) {
+        override fun onBind(item: String) {
+            binding.tvSelectedOptionItem.text = item
+        }
+    }
+}

--- a/app/src/main/java/com/example/seoulpublicservice/ui/map/MapViewModel.kt
+++ b/app/src/main/java/com/example/seoulpublicservice/ui/map/MapViewModel.kt
@@ -13,6 +13,7 @@ import com.example.seoulpublicservice.databases.ReservationEntity
 import com.example.seoulpublicservice.databases.ReservationRepository
 import com.example.seoulpublicservice.db_by_memory.DbMemoryRepository
 import com.example.seoulpublicservice.pref.FilterPrefRepository
+import com.example.seoulpublicservice.pref.SavedPrefRepository
 import com.example.seoulpublicservice.seoul.Row
 import com.example.seoulpublicservice.util.RoomRowMapper
 import kotlinx.coroutines.Dispatchers
@@ -22,6 +23,7 @@ import kotlinx.coroutines.withContext
 class MapViewModel(
     private val filterPrefRepository: FilterPrefRepository,
     private val reservationRepository: ReservationRepository,
+    private val savedPrefRepository: SavedPrefRepository,
     private val dbMemoryRepository: DbMemoryRepository,
 ) : ViewModel() {
 
@@ -115,6 +117,14 @@ class MapViewModel(
         }
     }
 
+    fun saveService(id: String) {
+        if (savedPrefRepository.savedSvcidListLiveData.value.orEmpty().contains(id)) {
+            savedPrefRepository.remove(id)
+        } else {
+            savedPrefRepository.addSvcid(id)
+        }
+    }
+
     fun moveReservationPage(url: String) {
         _moveToUrl.value = url
     }
@@ -158,6 +168,7 @@ class MapViewModel(
                 MapViewModel(
                     filterPrefRepository = container.filterPrefRepository,
                     reservationRepository = container.reservationRepository,
+                    savedPrefRepository = container.savedPrefRepository,
                     dbMemoryRepository = container.dbMemoryRepository
                 )
             }

--- a/app/src/main/res/drawable/background_white_with_f8496c_stroke.xml
+++ b/app/src/main/res/drawable/background_white_with_f8496c_stroke.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/white"/>
+    <corners android:radius="4dp"/>
+    <stroke android:color="@color/point_color" android:width="1dp"/>
+</shape>

--- a/app/src/main/res/layout/fragment_map.xml
+++ b/app/src/main/res/layout/fragment_map.xml
@@ -23,6 +23,18 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rv_map_selected_option"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginEnd="10dp"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constraintBottom_toBottomOf="@+id/tv_map_filter_btn"
+        app:layout_constraintStart_toStartOf="@+id/et_map_search"
+        app:layout_constraintTop_toTopOf="@+id/tv_map_filter_btn"
+        app:layout_constraintEnd_toStartOf="@+id/tv_map_filter_btn"/>
+
     <TextView
         android:id="@+id/tv_map_filter_btn"
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/item_selected_option.xml
+++ b/app/src/main/res/layout/item_selected_option.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:paddingVertical="2dp"
+    android:paddingHorizontal="10dp"
+    android:layout_marginHorizontal="4dp"
+    android:background="@drawable/background_white_with_f8496c_stroke">
+
+    <TextView
+        android:id="@+id/tv_selected_option_item"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="옵션"
+        android:textColor="@color/point_color"
+        android:textSize="14sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## PR 체크리스트
다음 요구사항을 충족하는지 확인해주세요

- [x] 커밋메세지 규칙을 따릅니다.

## PR 유형
어떤 변경사항이 있는지 모두 체크해 주세요

- [x] 기능구현
- [ ] 버그픽스
- [x] 리팩토링
- [ ] 문서 변경
- [x] 레이아웃
- [ ] 기타

## 변경사항 작성
<!-- 변경사항의 상세 정보를 작성해주세요. -->

-기능
저장 기능, 선택한 필터 보여주기 기능
Url 이미지 불러오는 코드 loadWithHolder로 변경
-설명
1. 서비스 상세 정보창에서 저장 버튼을 누르면 SharedPreference에 저장과 삭제가 되는 기능 구현(아이콘도 변경됨)
현재는 어댑터에 레포지토리를 넣어서 함수를 사용하는 방식으로 구현함(이후 프래그먼트로 람다식을 이용하여 뺀 다음 할 가능성 높음)

2. 필터 페이지에서 선택한 필터들이 지도페이지 필터 버튼 좌측에 뜨도록 기능 추가
가로 리사이클러뷰 사용
공간이 허락하는 큰 사이즈로 제작
선택한 필터들을 저장하는 SharedPreference에서 데이터들을 가져옴

3. 스플래시 페이지에서 오류나던거 잡기
Looper.prepare()를 토스트 메세지 코드 위에 추가하는 것으로
끝!

4. 지도 페이지 서비스 상세정보창에서 이미지를 띄울 때 만들어주신 loadWithHolder로 코드를 변경했습니다.
로딩 이미지를 조금 변경하면 좋을 거 같습니다.
한번 찾아볼게요
좀 더 얇고 작은 거나 gif만 가능하면 그것도 좋을 거 같네요

## Merge 후 브랜치 삭제 여부
- [ ] 반영된 브랜치 삭제