### PR TITLE
[ Feat ] : 현재 서비스의 후기 개수 주는 함수 추가

### DIFF
--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firebase/ServiceRepository.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firebase/ServiceRepository.kt
@@ -18,6 +18,10 @@ interface ServiceRepository {
     suspend fun getServiceReviews(
         svcId: String
     ) : List<ReviewItem>
+
+    suspend fun getServiceReviewsCount(
+        svcId: String
+    ) : Int
 }
 
 class ServiceRepositoryImpl: ServiceRepository {
@@ -85,6 +89,12 @@ class ServiceRepositoryImpl: ServiceRepository {
         }
 
         return resultList
+    }
+
+    override suspend fun getServiceReviewsCount(svcId: String): Int {
+        val service = getService(svcId)
+
+        return service?.reviewIdList?.size ?: 0
     }
 
     private suspend fun checkService(svcId: String): Boolean {


### PR DESCRIPTION
## PR 체크리스트
다음 요구사항을 충족하는지 확인해주세요

- [x] 커밋메세지 규칙을 따릅니다.

## PR 유형
어떤 변경사항이 있는지 모두 체크해 주세요

- [x] 기능구현
- [ ] 버그픽스
- [ ] 리팩토링
- [ ] 문서 변경
- [ ] 레이아웃
- [ ] 기타

## 변경사항 작성
<!-- 변경사항의 상세 정보를 작성해주세요. -->

-기능
현재 서비스의 후기 개수 주는 기능
-설명
ServiceRepository에 getServiceReviewsCount 함수를 만듬
현재 서비스를 찾아서 그 안에 있는 reviewIdList의 size를 반환함
reviewIdList는 후기가 없을 때 null이 가능하기 때문에 ?.과 ?: 연산자를 활용함

테스트는 안 하고 바로 올려서 혹~~~시나 안 되면 말해주셔요!!

## Merge 후 브랜치 삭제 여부
- [ ] 반영된 브랜치 삭제
