### PR TITLE
[ Feat ] : 리뷰 신고 기능 추가

### DIFF
--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firebase/ComplaintEntity.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firebase/ComplaintEntity.kt
@@ -1,0 +1,6 @@
+package com.wannabeinseoul.seoulpublicservice.databases.firebase
+
+data class ComplaintEntity(
+    val complaintId: String? = "",
+    val idList: List<String>? = emptyList()
+)

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firebase/ComplaintRepository.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firebase/ComplaintRepository.kt
@@ -1,0 +1,46 @@
+package com.wannabeinseoul.seoulpublicservice.databases.firebase
+
+import kotlinx.coroutines.tasks.await
+
+interface ComplaintRepository {
+    suspend fun addComplaint(id: String, complaintId: String): String
+}
+
+class ComplaintRepositoryImpl : ComplaintRepository {
+    override suspend fun addComplaint(id: String, complaintId: String): String {
+        if (!checkComplaintId(complaintId)) {
+            FBRef.complaintRef.child(complaintId).setValue(ComplaintEntity(complaintId))
+        }
+
+        val complaintSnapshot = FBRef.complaintRef.get().await()
+
+        for (snapshot in complaintSnapshot.children) {
+            if (snapshot.key == complaintId) {
+                val targetComplaintId = snapshot.getValue(ComplaintEntity::class.java)
+                if (targetComplaintId?.idList?.contains(id) == true) {
+                    return "이미 신고한 사용자입니다."
+                } else {
+                    FBRef.complaintRef.child(complaintId).setValue(
+                        targetComplaintId?.copy(
+                            idList = targetComplaintId.idList.orEmpty().toMutableList() + id
+                        )
+                    )
+                    return "신고했습니다."
+                }
+            }
+        }
+
+        return ""
+    }
+
+    private suspend fun checkComplaintId(complaintId: String): Boolean {
+        val serviceSnapshot = FBRef.complaintRef.get().await()
+
+        for (snapshot in serviceSnapshot.children) {
+            if (snapshot.key == complaintId) {
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firebase/FBRef.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firebase/FBRef.kt
@@ -9,5 +9,6 @@ class FBRef {
         val reviewRef = database.getReference("review")
         val userRef = database.getReference("user")
         val serviceRef = database.getReference("service")
+        val complaintRef = database.getReference("complaint")
     }
 }

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firebase/ServiceRepository.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firebase/ServiceRepository.kt
@@ -39,7 +39,7 @@ class ServiceRepositoryImpl: ServiceRepository {
             FBRef.serviceRef.child(svcId).setValue(ServiceEntity(svcId))
         }
 
-        var serviceSnapshot = FBRef.serviceRef.get().await()
+        val serviceSnapshot = FBRef.serviceRef.get().await()
 
         var targetService: ServiceEntity? = null
         for (snapshot in serviceSnapshot.children) {

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firebase/UserRepository.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firebase/UserRepository.kt
@@ -17,6 +17,10 @@ interface UserRepository {
         id: String
     ) : UserEntity?
 
+    suspend fun getUserId(
+        name: String
+    ) : String
+
     suspend fun getReview(
         id: String
     ) : List<ReviewEntity>
@@ -47,6 +51,19 @@ class UserRepositoryImpl: UserRepository {
         }
 
         return targetUser
+    }
+
+    override suspend fun getUserId(name: String): String {
+        val userSnapshot = FBRef.userRef.get().await()
+
+        for (snapshot in userSnapshot.children) {
+            val user = snapshot.getValue(UserEntity::class.java)
+            if (user?.userName == name) {
+                return snapshot.key!!
+            }
+        }
+
+        return ""
     }
 
     override suspend fun getReview(id: String): List<ReviewEntity> {

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/di/AppContainer.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/di/AppContainer.kt
@@ -7,6 +7,8 @@ import com.wannabeinseoul.seoulpublicservice.pref.SearchPrefRepositoryImpl
 import com.wannabeinseoul.seoulpublicservice.databases.ReservationDatabase
 import com.wannabeinseoul.seoulpublicservice.databases.ReservationRepository
 import com.wannabeinseoul.seoulpublicservice.databases.ReservationRepositoryImpl
+import com.wannabeinseoul.seoulpublicservice.databases.firebase.ComplaintRepository
+import com.wannabeinseoul.seoulpublicservice.databases.firebase.ComplaintRepositoryImpl
 import com.wannabeinseoul.seoulpublicservice.databases.firebase.ReviewRepository
 import com.wannabeinseoul.seoulpublicservice.databases.firebase.ReviewRepositoryImpl
 import com.wannabeinseoul.seoulpublicservice.databases.firebase.ServiceRepository
@@ -61,6 +63,7 @@ interface AppContainer {
     val reviewRepository: ReviewRepository
     val userRepository: UserRepository
     val serviceRepository: ServiceRepository
+    val complaintRepository: ComplaintRepository
 }
 
 class DefaultAppContainer(context: Context, getAppRowList: () -> List<Row>) : AppContainer {
@@ -162,5 +165,9 @@ class DefaultAppContainer(context: Context, getAppRowList: () -> List<Row>) : Ap
 
     override val serviceRepository: ServiceRepository by lazy {
         ServiceRepositoryImpl()
+    }
+
+    override val complaintRepository: ComplaintRepository by lazy {
+        ComplaintRepositoryImpl()
     }
 }

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/dialog/complaint/ComplaintFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/dialog/complaint/ComplaintFragment.kt
@@ -1,0 +1,69 @@
+package com.wannabeinseoul.seoulpublicservice.dialog.complaint
+
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.Window
+import android.widget.Toast
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.viewModels
+import com.wannabeinseoul.seoulpublicservice.R
+import com.wannabeinseoul.seoulpublicservice.databinding.FragmentComplaintBinding
+
+class ComplaintFragment(private val name: String) : DialogFragment() {
+
+    companion object {
+        fun newInstance(name: String) = ComplaintFragment(name)
+    }
+
+    private var _binding: FragmentComplaintBinding? = null
+    private val binding get() = _binding!!
+
+    private val viewModel: ComplaintViewModel by viewModels { ComplaintViewModel.factory }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentComplaintBinding.inflate(inflater, container, false)
+
+        dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+        dialog?.window?.requestFeature(Window.FEATURE_NO_TITLE)
+
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        initView()
+        initViewModel()
+    }
+
+    private fun initView() = with(binding) {
+        tvComplaintDescription.text = requireContext().getString(R.string.complaint_description, name)
+
+        btnComplaintCancel.setOnClickListener {
+            dismiss()
+        }
+
+        btnComplaintOkay.setOnClickListener {
+            viewModel.addComplaint(name)
+        }
+    }
+
+    private fun initViewModel() = with(viewModel) {
+        resultString.observe(viewLifecycleOwner) {
+            if (it == "신고했습니다.") {
+                Toast.makeText(requireContext(), "${name}을(를) $it", Toast.LENGTH_SHORT).show()
+            } else {
+                Toast.makeText(requireContext(), it, Toast.LENGTH_SHORT).show()
+            }
+
+            dismiss()
+        }
+    }
+}

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/dialog/complaint/ComplaintViewModel.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/dialog/complaint/ComplaintViewModel.kt
@@ -1,0 +1,49 @@
+package com.wannabeinseoul.seoulpublicservice.dialog.complaint
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.wannabeinseoul.seoulpublicservice.SeoulPublicServiceApplication
+import com.wannabeinseoul.seoulpublicservice.databases.firebase.ComplaintRepository
+import com.wannabeinseoul.seoulpublicservice.databases.firebase.UserRepository
+import com.wannabeinseoul.seoulpublicservice.dialog.review.ReviewViewModel
+import com.wannabeinseoul.seoulpublicservice.pref.IdPrefRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class ComplaintViewModel(
+    private val idPrefRepository: IdPrefRepository,
+    private val userRepository: UserRepository,
+    private val complaintRepository: ComplaintRepository
+) : ViewModel() {
+
+    private val _resultString: MutableLiveData<String> = MutableLiveData()
+    val resultString: LiveData<String> get() = _resultString
+
+    fun addComplaint(name: String) {
+        viewModelScope.launch(Dispatchers.IO) {
+            val id = userRepository.getUserId(name)
+
+            _resultString.postValue(complaintRepository.addComplaint(idPrefRepository.load(), id))
+        }
+    }
+
+    companion object {
+        val factory = viewModelFactory {
+            initializer {
+                val application =
+                    (this[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY] as SeoulPublicServiceApplication)
+                val container = application.container
+                ComplaintViewModel(
+                    idPrefRepository = container.idPrefRepository,
+                    userRepository = container.userRepository,
+                    complaintRepository = container.complaintRepository
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/dialog/review/ReviewFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/dialog/review/ReviewFragment.kt
@@ -16,7 +16,9 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.wannabeinseoul.seoulpublicservice.R
+import com.wannabeinseoul.seoulpublicservice.SeoulPublicServiceApplication
 import com.wannabeinseoul.seoulpublicservice.databinding.FragmentReviewBinding
+import com.wannabeinseoul.seoulpublicservice.dialog.complaint.ComplaintFragment
 
 class ReviewFragment(
     private val svcId: String,
@@ -28,10 +30,17 @@ class ReviewFragment(
 
     private val viewModel: ReviewViewModel by viewModels { ReviewViewModel.factory }
 
+    private val app by lazy {
+        requireActivity().application as SeoulPublicServiceApplication
+    }
+    private val container by lazy {
+        app.container
+    }
+
     private val adapter: ReviewAdapter by lazy {
         ReviewAdapter(
             complaintUser = {
-                Toast.makeText(requireContext(), "${it}에 대한 신고가 접수되었습니다.", Toast.LENGTH_SHORT).show()
+                viewModel.checkComplaintSelf(it)
             }
         )
     }
@@ -130,6 +139,14 @@ class ReviewFragment(
                 }
             }
         }
+
+        isComplaintSelf.observe(viewLifecycleOwner) {
+            if (it.first) {
+                Toast.makeText(requireContext(), "스스로를 신고할 수는 없습니다.", Toast.LENGTH_SHORT).show()
+            } else {
+                ComplaintFragment.newInstance(it.second).show(requireActivity().supportFragmentManager, "Complaint")
+            }
+        }
     }
 
     private fun setInitialState() {
@@ -143,14 +160,4 @@ class ReviewFragment(
             0
         )
     }
-
-//    companion object {
-//        @JvmStatic
-//        fun newInstance(serviceID: String) =
-//            ReviewFragment().apply {
-//                arguments = Bundle().apply {
-//                    putString(REVIEW_PARAM, serviceID)
-//                }
-//            }
-//    }
 }

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/dialog/review/ReviewViewModel.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/dialog/review/ReviewViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.wannabeinseoul.seoulpublicservice.SeoulPublicServiceApplication
+import com.wannabeinseoul.seoulpublicservice.databases.firebase.ComplaintRepository
 import com.wannabeinseoul.seoulpublicservice.databases.firebase.ReviewEntity
 import com.wannabeinseoul.seoulpublicservice.databases.firebase.ReviewRepository
 import com.wannabeinseoul.seoulpublicservice.databases.firebase.ServiceRepository
@@ -22,7 +23,8 @@ class ReviewViewModel(
     private val idPrefRepository: IdPrefRepository,
     private val reviewRepository: ReviewRepository,
     private val userRepository: UserRepository,
-    private val serviceRepository: ServiceRepository
+    private val serviceRepository: ServiceRepository,
+    private val complaintRepository: ComplaintRepository
 ) : ViewModel() {
 
     private val _uiState: MutableLiveData<List<ReviewItem>> = MutableLiveData()
@@ -30,6 +32,9 @@ class ReviewViewModel(
 
     private val _reviewCredentials: MutableLiveData<Boolean> = MutableLiveData()
     val reviewCredentials: LiveData<Boolean> get() = _reviewCredentials
+
+    private val _isComplaintSelf: MutableLiveData<Pair<Boolean, String>> = MutableLiveData()
+    val isComplaintSelf: LiveData<Pair<Boolean, String>> get() = _isComplaintSelf
 
     fun uploadReview(svcId: String, review: String) {
         viewModelScope.launch(Dispatchers.IO) {
@@ -79,6 +84,18 @@ class ReviewViewModel(
         }
     }
 
+    fun checkComplaintSelf(name: String) {
+        viewModelScope.launch(Dispatchers.IO) {
+            val id = userRepository.getUserId(name)
+
+            if (id == idPrefRepository.load()) {
+                _isComplaintSelf.postValue(Pair(true, name))
+            } else {
+                _isComplaintSelf.postValue(Pair(false, name))
+            }
+        }
+    }
+
     companion object {
         /** 뷰모델팩토리에서 의존성주입을 해준다 */
         val factory = viewModelFactory {
@@ -90,7 +107,8 @@ class ReviewViewModel(
                     idPrefRepository = container.idPrefRepository,
                     reviewRepository = container.reviewRepository,
                     userRepository = container.userRepository,
-                    serviceRepository = container.serviceRepository
+                    serviceRepository = container.serviceRepository,
+                    complaintRepository = container.complaintRepository
                 )
             }
         }

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/mypage/EditProfileDialog.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/mypage/EditProfileDialog.kt
@@ -1,9 +1,12 @@
 package com.wannabeinseoul.seoulpublicservice.ui.mypage
 
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.Window
 import androidx.fragment.app.DialogFragment
 import com.wannabeinseoul.seoulpublicservice.databinding.DialogEditProfileBinding
 
@@ -21,6 +24,10 @@ class EditProfileDialog : DialogFragment() {
         savedInstanceState: Bundle?
     ): View {
         _binding = DialogEditProfileBinding.inflate(inflater, container, false)
+
+        dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+        dialog?.window?.requestFeature(Window.FEATURE_NO_TITLE)
+
         return binding.root
     }
 

--- a/app/src/main/res/layout/fragment_complaint.xml
+++ b/app/src/main/res/layout/fragment_complaint.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:background="@drawable/background_radius_10dp"
+    android:elevation="5dp"
+    android:clipToOutline="true"
+    tools:context=".dialog.complaint.ComplaintFragment">
+
+    <TextView
+        android:id="@+id/tv_complaint_description"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="xx님을 신고하시겠습니까?"
+        android:layout_marginTop="20dp"
+        android:layout_marginHorizontal="40dp"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btn_complaint_cancel"
+        android:layout_width="0dp"
+        android:layout_height="30dp"
+        android:layout_marginEnd="5dp"
+        android:layout_marginVertical="20dp"
+        android:background="@drawable/background_radius_10dp_828282"
+        android:text="취소"
+        android:textColor="@color/white"
+        android:textSize="14sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/btn_complaint_okay"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="@+id/tv_complaint_description"
+        app:layout_constraintTop_toBottomOf="@+id/tv_complaint_description" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/btn_complaint_okay"
+        android:layout_width="0dp"
+        android:layout_height="30dp"
+        android:layout_marginStart="5dp"
+        android:background="@drawable/background_radius_10dp_ff6685"
+        android:text="확인"
+        android:textColor="@color/white"
+        android:textSize="14sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="@+id/btn_complaint_cancel"
+        app:layout_constraintEnd_toEndOf="@+id/tv_complaint_description"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toEndOf="@+id/btn_complaint_cancel"
+        app:layout_constraintTop_toTopOf="@+id/btn_complaint_cancel" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="title_map">지도 페이지</string>
     <string name="title_recommendation">추천 페이지</string>
     <string name="title_mypage">마이 페이지</string>
+    <string name="complaint_description">%s님을 신고하시겠습니까?</string>
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
 </resources>


### PR DESCRIPTION
## PR 체크리스트
다음 요구사항을 충족하는지 확인해주세요

- [x] 커밋메세지 규칙을 따릅니다.

## PR 유형
어떤 변경사항이 있는지 모두 체크해 주세요

- [x] 기능구현
- [ ] 버그픽스
- [ ] 리팩토링
- [ ] 문서 변경
- [x] 레이아웃
- [ ] 기타

## 변경사항 작성
<!-- 변경사항의 상세 정보를 작성해주세요. -->

-기능
후기 작성 페이지에서 후기를 롱클릭할 시 사용자를 신고할 수 있는 기능 
-설명
신고를 관리하는 ComplaintRepository 생성함
해당 레포지토리에는 신고당하는 유저ID와 신고한 유저ID 리스트가 저장됨

후기 작성 페이지에서 후기를 롱클릭하는 경우 신고 확인 다이얼로그로 넘어감
(본인이 본인의 댓글을 롱클릭하는 경우 다이얼로그로 넘어가지 않고 자기자신은 신고할 수 없다는 토스트 메세지를 띄워줌 -> 처음에는 간단하게 조건문으로 하려고 했지만 잘 안 돼서 뷰모델 함수 호출해 자기자신을 확인하고 LiveData 값을 줬다.) 
거기서 확인을 누르면 먼저 유저 테이블에서 해당 이름을 가진 유저 ID를 찾고 이미 신고한 유저인지 아닌지 확인하고 이미 신고한 유저이면 데이터베이스에 저장하지 않고 이미 신고한 유저라는 토스트메세지만 띄워주고 아니라면 데이터베이스에 저장하고 신고했음을 알려주는 토스트 메세지를 띄워준다.

아마 신고한 유저에 대한 후속 처리는 개발자가 DB를 보다가 일정 숫자 이상의 신고를 받은 유저 ID를 제거하고 해당 유저ID를 가지고 있는 사람이 앱을 실행할 때 스플래시 페이지에서 ID가 없는 경우 앱을 거기서 종료시키는 방법을 쓸 수 있지 않을까 싶다.

## Merge 후 브랜치 삭제 여부
- [ ] 반영된 브랜치 삭제