### PR TITLE
[ Fix ] : 지도 페이지 예외 처리

### DIFF
--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/InterestRegionSelectActivity.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/InterestRegionSelectActivity.kt
@@ -73,6 +73,7 @@ class InterestRegionSelectActivity : AppCompatActivity() {
         viewModel.loadRegion()
 
         ivInterestRegionSelectBackBtn.setOnClickListener {
+            setResult(RESULT_OK)
             finish()
         }
 

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/DetailInfoWindow.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/DetailInfoWindow.kt
@@ -1,0 +1,12 @@
+package com.wannabeinseoul.seoulpublicservice.ui.map
+
+data class DetailInfoWindow(
+    val svcid: String,
+    val imgurl: String,
+    val areanm: String,
+    val svcnm: String,
+    val payatnm: String,
+    val svcstatnm: String,
+    val svcurl: String,
+    val saved: Boolean = false
+)

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapDetailInfoAdapter.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapDetailInfoAdapter.kt
@@ -19,23 +19,23 @@ class MapDetailInfoAdapter(
     private val shareUrl: (String) -> Unit,
     private val moveDetailPage: (String) -> Unit,
     private val savedPrefRepository: SavedPrefRepository
-) : ListAdapter<Row, MapDetailInfoAdapter.InfoViewHolder>(object : DiffUtil.ItemCallback<Row>() {
-    override fun areItemsTheSame(oldItem: Row, newItem: Row): Boolean {
+) : ListAdapter<DetailInfoWindow, MapDetailInfoAdapter.InfoViewHolder>(object : DiffUtil.ItemCallback<DetailInfoWindow>() {
+    override fun areItemsTheSame(oldItem: DetailInfoWindow, newItem: DetailInfoWindow): Boolean {
         return oldItem.svcid == newItem.svcid
     }
 
-    override fun areContentsTheSame(oldItem: Row, newItem: Row): Boolean {
+    override fun areContentsTheSame(oldItem: DetailInfoWindow, newItem: DetailInfoWindow): Boolean {
         return oldItem == newItem
     }
 
 }) {
     abstract class InfoViewHolder(view: View) : RecyclerView.ViewHolder(view) {
-        abstract fun onBind(item: Row)
+        abstract fun onBind(item: DetailInfoWindow)
     }
 
     override fun getItemViewType(position: Int): Int {
         val info = getItem(position)
-        return if (info is Row) {
+        return if (info is DetailInfoWindow) {
             0
         } else {
             1
@@ -83,8 +83,8 @@ class MapDetailInfoAdapter(
         private val moveDetailPage: (String) -> Unit,
         private val savedPrefRepository: SavedPrefRepository
     ) : InfoViewHolder(binding.root) {
-        override fun onBind(item: Row) = with(binding) {
-            if (savedPrefRepository.contains(item.svcid)) {
+        override fun onBind(item: DetailInfoWindow) = with(binding) {
+            if (item.saved) {
                 ivMapInfoSaveServiceBtn.setImageResource(R.drawable.ic_save_fill)
             } else {
                 ivMapInfoSaveServiceBtn.setImageResource(R.drawable.ic_save_empty)
@@ -144,6 +144,6 @@ class MapDetailInfoAdapter(
     class UnknownInfoViewHolder(
         private val binding: ItemMapInfoWindowBinding
     ) : InfoViewHolder(binding.root) {
-        override fun onBind(item: Row) = Unit
+        override fun onBind(item: DetailInfoWindow) = Unit
     }
 }

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapViewModel.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapViewModel.kt
@@ -46,23 +46,11 @@ class MapViewModel(
         MutableLiveData()
     val filteringData: LiveData<HashMap<Pair<String, String>, List<Row>>> get() = _filteringData
 
-    private var _updateData: MutableLiveData<List<Row>> = MutableLiveData()
-    val updateData: LiveData<List<Row>> get() = _updateData
+    private var _updateData: MutableLiveData<List<DetailInfoWindow>> = MutableLiveData()
+    val updateData: LiveData<List<DetailInfoWindow>> get() = _updateData
 
     private var _moveToUrl: MutableLiveData<String> = MutableLiveData()
     val moveToUrl: LiveData<String> get() = _moveToUrl
-
-    private var _shareUrl: MutableLiveData<String> = MutableLiveData()
-    val shareUrl: LiveData<String> get() = _shareUrl
-
-    private var _detailInfoId: MutableLiveData<String> = MutableLiveData()
-    val detailInfoId: LiveData<String> get() = _detailInfoId
-
-    private var _reviews: MutableLiveData<List<ReviewEntity>> = MutableLiveData()
-    val reviews: LiveData<List<ReviewEntity>> get() = _reviews
-
-    private var _user: MutableLiveData<UserEntity> = MutableLiveData()
-    val user: LiveData<UserEntity> get() = _user
 
     fun loadSavedOptions() {
         _canStart.value = false
@@ -131,20 +119,23 @@ class MapViewModel(
         _moveToUrl.value = url
     }
 
-    fun shareReservationPage(url: String) {
-        _shareUrl.value = url
-    }
-
-    fun moveDetailPage(id: String) {
-        _detailInfoId.value = id
-    }
-
     fun changeVisible(flag: Boolean) {
         _visibleInfoWindow.value = flag
     }
 
     fun updateInfo(info: List<Row>) {
-        _updateData.value = info
+        _updateData.value = info.map {
+            DetailInfoWindow(
+                svcid = it.svcid,
+                imgurl = it.imgurl,
+                areanm = it.areanm,
+                svcnm = it.svcnm,
+                payatnm = it.payatnm,
+                svcstatnm = it.svcstatnm,
+                svcurl = it.svcurl,
+                saved = savedPrefRepository.contains(it.svcid)
+            )
+        }
     }
 
     fun initMap() {
@@ -157,8 +148,6 @@ class MapViewModel(
         _visibleInfoWindow = MutableLiveData()
         _updateData = MutableLiveData()
         _moveToUrl = MutableLiveData()
-        _shareUrl = MutableLiveData()
-        _detailInfoId = MutableLiveData()
     }
 
     companion object {


### PR DESCRIPTION
## PR 체크리스트
다음 요구사항을 충족하는지 확인해주세요

- [x] 커밋메세지 규칙을 따릅니다.

## PR 유형
어떤 변경사항이 있는지 모두 체크해 주세요

- [x] 기능구현
- [x] 버그픽스
- [x] 리팩토링
- [ ] 문서 변경
- [ ] 레이아웃
- [ ] 기타

## 변경사항 작성
<!-- 변경사항의 상세 정보를 작성해주세요. -->

-기능
지도 페이지에서 잘 발견하지 못했던 예외처리들을 처리
-설명
1. 상세 페이지에서 누른 저장 버튼이 지도 페이지 상세정보창에 바로 업데이트 되지 않는 문제
기존 상세정보창에 들어가는 데이터는 저장 정보가 없어 이것에 대한 변경사항을 알 수 없던 것이 원인이었다.
어댑터에 들어가는 데이터 클래스를 따로 만들어 그 안에 저장 정보를 넣어 저장 정보가 변경되었다면 submitList했을 때 리사이클러뷰가 업데이트하도록 변경

2. 관심지역선택액티비티에서 뒤로가기 버튼을 누르고 홈 프래그먼트로 돌아왔을 때 관심지역 리스트가 모두 회색으로 보이는 문제
registerForActivityResult가 작동하지 않고 관심지역 재설정 버튼 클릭 리스너만 작동하던 것이 원인이었다.
뒤로가기버튼에도 setResult(RESULT_OK)를 달아주니까 해결

3. 상세정보창을 통해 외부 앱을 갔다가 오면 뷰모델 옵저빙이 다 멈춰버리는 문제
처음에 외부 앱을 갔다가 마커를 눌렀을 때 반응이 없을 때 느낌이 싸했는데 다른 기능들도 스톱이 되있더라
외부앱을 갈 때에 앱의 생명주기의 변화로 인해 생기는 문제였다.
이걸 해결하기 위해 onResume에 initViewModel 함수를 초기화하여 옵저버를 다시 설정하는 방법을 사용했다.

4. 공유 기능 무한 츠쿠요미
위의 방법을 썼을 때 공유 기능을 닫아도 닫아도 계속 열리는 문제가 있었다.
공유 기능이 액티비티를 부르는 형태이다 보니까 onResume이 계속 일어나고 라이브데이터에 들어가있는 값이 계속 옵저빙이 되는 걸로 판단해 공유 기능은 뷰모델에서 처리하는 것이 아니라 람다식 안에서 처리하도록 변경함

5. 상세페이지 두배로 열기
상세정보창에서 상세 페이지를 열 때 두개씩 열리는 문제가 있었다.
터치가 두번 된 건가 싶어서 디버깅을 해봤지만 그냥 show가 두번 호출되더라
이것도 위의 옵저버 호출관련으로 생긴 문제로 판단하고 람다식 안에서 처리하도록 변경함

## Merge 후 브랜치 삭제 여부
- [ ] 반영된 브랜치 삭제