### PR TITLE
[ Feat & Refactor ] : 신고 기능 보완

### DIFF
--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firebase/ComplaintEntity.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firebase/ComplaintEntity.kt
@@ -1,6 +1,9 @@
 package com.wannabeinseoul.seoulpublicservice.databases.firebase
 
 data class ComplaintEntity(
-    val complaintId: String? = "",
-    val idList: List<String>? = emptyList()
+    val complaintId: String? = "",      // 신고당한 사람
+    val complaintTime: String? = "",
+    val reviewId: String? = "",
+    val id: String? = "",               // 신고한 사람
+    val svcId: String? = ""
 )

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firebase/ComplaintRepository.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firebase/ComplaintRepository.kt
@@ -3,30 +3,31 @@ package com.wannabeinseoul.seoulpublicservice.databases.firebase
 import kotlinx.coroutines.tasks.await
 
 interface ComplaintRepository {
-    suspend fun addComplaint(id: String, complaintId: String): String
+    suspend fun addComplaint(content: ComplaintEntity): String
 }
 
 class ComplaintRepositoryImpl : ComplaintRepository {
-    override suspend fun addComplaint(id: String, complaintId: String): String {
-        if (!checkComplaintId(complaintId)) {
-            FBRef.complaintRef.child(complaintId).setValue(ComplaintEntity(complaintId))
+    override suspend fun addComplaint(content: ComplaintEntity): String {
+        if (!checkComplaintId(content.complaintId.toString())) {
+            FBRef.complaintRef.child(content.complaintId.toString())
+                .child(content.complaintTime.toString()).setValue(content)
+
+            decideAddBanList(content.complaintId.toString())
+
+            return "신고했습니다."
         }
 
-        val complaintSnapshot = FBRef.complaintRef.get().await()
+        val complaintSnapshot =
+            FBRef.complaintRef.child(content.complaintId.toString()).get().await()
+
+        if (complaintSnapshot.childrenCount >= 3) {
+            FBRef.userBanRef.child(content.complaintId.toString()).setValue(content.complaintId)
+        }
 
         for (snapshot in complaintSnapshot.children) {
-            if (snapshot.key == complaintId) {
-                val targetComplaintId = snapshot.getValue(ComplaintEntity::class.java)
-                if (targetComplaintId?.idList?.contains(id) == true) {
-                    return "이미 신고한 사용자입니다."
-                } else {
-                    FBRef.complaintRef.child(complaintId).setValue(
-                        targetComplaintId?.copy(
-                            idList = targetComplaintId.idList.orEmpty().toMutableList() + id
-                        )
-                    )
-                    return "신고했습니다."
-                }
+            val complaint = snapshot.getValue(ComplaintEntity::class.java)
+            if (complaint?.id == content.id) {
+                return "이미 신고한 사용자입니다."
             }
         }
 
@@ -42,5 +43,14 @@ class ComplaintRepositoryImpl : ComplaintRepository {
             }
         }
         return false
+    }
+
+    private suspend fun decideAddBanList(complaintId: String) {
+        val complaintSnapshot =
+            FBRef.complaintRef.child(complaintId).get().await()
+
+        if (complaintSnapshot.childrenCount >= 3) {
+            FBRef.userBanRef.child(complaintId).setValue(complaintId)
+        }
     }
 }

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firebase/FBRef.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firebase/FBRef.kt
@@ -10,5 +10,6 @@ class FBRef {
         val userRef = database.getReference("user")
         val serviceRef = database.getReference("service")
         val complaintRef = database.getReference("complaint")
+        val userBanRef = database.getReference("userBan")
     }
 }

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firebase/ReviewRepository.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firebase/ReviewRepository.kt
@@ -7,6 +7,8 @@ interface ReviewRepository {
 
     suspend fun reviseReview(id: String, svcId: String, review: String)
 
+    suspend fun getReviewId(svcId: String, userId: String): String
+
     suspend fun checkCredentials(id: String, svcId: String): Boolean
 }
 
@@ -26,6 +28,19 @@ class ReviewRepositoryImpl : ReviewRepository {
                 break
             }
         }
+    }
+
+    override suspend fun getReviewId(svcId: String, userId: String): String {
+        val serviceSnapshot = FBRef.reviewRef.get().await()
+
+        for (snapshot in serviceSnapshot.children) {
+            val review = snapshot.getValue(ReviewEntity::class.java)
+            if (review?.userId == userId && review.svcId == svcId) {
+                return snapshot.key.toString()
+            }
+        }
+
+        return ""
     }
 
     override suspend fun checkCredentials(id: String, svcId: String): Boolean {

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firebase/ServiceRepository.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firebase/ServiceRepository.kt
@@ -72,7 +72,6 @@ class ServiceRepositoryImpl: ServiceRepository {
         val resultList: MutableList<ReviewItem> = mutableListOf()
         targetReviewList.forEach { review ->
             for (snapshot in userSnapShot.children) {
-                Log.d("dkj", "${snapshot.key} ${review.userId}")
                 if (snapshot.key == review.userId) {
                     val user = snapshot.getValue(UserEntity::class.java)
                     resultList.add(ReviewItem(

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firebase/UserBanRepository.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firebase/UserBanRepository.kt
@@ -1,0 +1,13 @@
+package com.wannabeinseoul.seoulpublicservice.databases.firebase
+
+import kotlinx.coroutines.tasks.await
+
+interface UserBanRepository {
+    suspend fun getBanList(): List<String>
+}
+
+class UserBanRepositoryImpl: UserBanRepository {
+    override suspend fun getBanList(): List<String> {
+        return FBRef.userBanRef.get().await().children.map { it.value.toString() }
+    }
+}

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/di/AppContainer.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/di/AppContainer.kt
@@ -13,6 +13,8 @@ import com.wannabeinseoul.seoulpublicservice.databases.firebase.ReviewRepository
 import com.wannabeinseoul.seoulpublicservice.databases.firebase.ReviewRepositoryImpl
 import com.wannabeinseoul.seoulpublicservice.databases.firebase.ServiceRepository
 import com.wannabeinseoul.seoulpublicservice.databases.firebase.ServiceRepositoryImpl
+import com.wannabeinseoul.seoulpublicservice.databases.firebase.UserBanRepository
+import com.wannabeinseoul.seoulpublicservice.databases.firebase.UserBanRepositoryImpl
 import com.wannabeinseoul.seoulpublicservice.databases.firebase.UserRepository
 import com.wannabeinseoul.seoulpublicservice.databases.firebase.UserRepositoryImpl
 import com.wannabeinseoul.seoulpublicservice.db_by_memory.DbMemoryRepository
@@ -64,6 +66,7 @@ interface AppContainer {
     val userRepository: UserRepository
     val serviceRepository: ServiceRepository
     val complaintRepository: ComplaintRepository
+    val userBanRepository: UserBanRepository
 }
 
 class DefaultAppContainer(context: Context, getAppRowList: () -> List<Row>) : AppContainer {
@@ -169,5 +172,9 @@ class DefaultAppContainer(context: Context, getAppRowList: () -> List<Row>) : Ap
 
     override val complaintRepository: ComplaintRepository by lazy {
         ComplaintRepositoryImpl()
+    }
+
+    override val userBanRepository: UserBanRepository by lazy {
+        UserBanRepositoryImpl()
     }
 }

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/dialog/complaint/ComplaintFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/dialog/complaint/ComplaintFragment.kt
@@ -1,5 +1,6 @@
 package com.wannabeinseoul.seoulpublicservice.dialog.complaint
 
+import android.content.DialogInterface
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
@@ -13,11 +14,11 @@ import androidx.fragment.app.viewModels
 import com.wannabeinseoul.seoulpublicservice.R
 import com.wannabeinseoul.seoulpublicservice.databinding.FragmentComplaintBinding
 
-class ComplaintFragment(private val name: String) : DialogFragment() {
-
-    companion object {
-        fun newInstance(name: String) = ComplaintFragment(name)
-    }
+class ComplaintFragment(
+    private val svcId: String,
+    private val name: String,
+    private val clickOk: () -> Unit
+) : DialogFragment() {
 
     private var _binding: FragmentComplaintBinding? = null
     private val binding get() = _binding!!
@@ -51,7 +52,7 @@ class ComplaintFragment(private val name: String) : DialogFragment() {
         }
 
         btnComplaintOkay.setOnClickListener {
-            viewModel.addComplaint(name)
+            viewModel.addComplaint(svcId, name)
         }
     }
 
@@ -65,5 +66,10 @@ class ComplaintFragment(private val name: String) : DialogFragment() {
 
             dismiss()
         }
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        clickOk()
+        super.onDismiss(dialog)
     }
 }

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/dialog/complaint/ComplaintViewModel.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/dialog/complaint/ComplaintViewModel.kt
@@ -8,27 +8,44 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.wannabeinseoul.seoulpublicservice.SeoulPublicServiceApplication
+import com.wannabeinseoul.seoulpublicservice.databases.firebase.ComplaintEntity
 import com.wannabeinseoul.seoulpublicservice.databases.firebase.ComplaintRepository
+import com.wannabeinseoul.seoulpublicservice.databases.firebase.ReviewRepository
 import com.wannabeinseoul.seoulpublicservice.databases.firebase.UserRepository
 import com.wannabeinseoul.seoulpublicservice.dialog.review.ReviewViewModel
 import com.wannabeinseoul.seoulpublicservice.pref.IdPrefRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 class ComplaintViewModel(
     private val idPrefRepository: IdPrefRepository,
     private val userRepository: UserRepository,
+    private val reviewRepository: ReviewRepository,
     private val complaintRepository: ComplaintRepository
 ) : ViewModel() {
 
     private val _resultString: MutableLiveData<String> = MutableLiveData()
     val resultString: LiveData<String> get() = _resultString
 
-    fun addComplaint(name: String) {
+    fun addComplaint(svcId: String, name: String) {
         viewModelScope.launch(Dispatchers.IO) {
             val id = userRepository.getUserId(name)
+            val reviewId = reviewRepository.getReviewId(svcId, id)
 
-            _resultString.postValue(complaintRepository.addComplaint(idPrefRepository.load(), id))
+            _resultString.postValue(
+                complaintRepository.addComplaint(
+                    ComplaintEntity(
+                        id,
+                        LocalDateTime.now()
+                            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
+                        reviewId,
+                        idPrefRepository.load(),
+                        svcId
+                    )
+                )
+            )
         }
     }
 
@@ -41,6 +58,7 @@ class ComplaintViewModel(
                 ComplaintViewModel(
                     idPrefRepository = container.idPrefRepository,
                     userRepository = container.userRepository,
+                    reviewRepository = container.reviewRepository,
                     complaintRepository = container.complaintRepository
                 )
             }

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/dialog/review/ReviewFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/dialog/review/ReviewFragment.kt
@@ -144,7 +144,10 @@ class ReviewFragment(
             if (it.first) {
                 Toast.makeText(requireContext(), "스스로를 신고할 수는 없습니다.", Toast.LENGTH_SHORT).show()
             } else {
-                ComplaintFragment.newInstance(it.second).show(requireActivity().supportFragmentManager, "Complaint")
+                val complaintFragment = ComplaintFragment(svcId, it.second) {
+                    setReviews(svcId)
+                }
+                complaintFragment.show(requireActivity().supportFragmentManager, "Complaint")
             }
         }
     }

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/dialog/review/ReviewViewModel.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/dialog/review/ReviewViewModel.kt
@@ -12,6 +12,7 @@ import com.wannabeinseoul.seoulpublicservice.databases.firebase.ComplaintReposit
 import com.wannabeinseoul.seoulpublicservice.databases.firebase.ReviewEntity
 import com.wannabeinseoul.seoulpublicservice.databases.firebase.ReviewRepository
 import com.wannabeinseoul.seoulpublicservice.databases.firebase.ServiceRepository
+import com.wannabeinseoul.seoulpublicservice.databases.firebase.UserBanRepository
 import com.wannabeinseoul.seoulpublicservice.databases.firebase.UserRepository
 import com.wannabeinseoul.seoulpublicservice.pref.IdPrefRepository
 import kotlinx.coroutines.Dispatchers
@@ -24,7 +25,7 @@ class ReviewViewModel(
     private val reviewRepository: ReviewRepository,
     private val userRepository: UserRepository,
     private val serviceRepository: ServiceRepository,
-    private val complaintRepository: ComplaintRepository
+    private val userBanRepository: UserBanRepository
 ) : ViewModel() {
 
     private val _uiState: MutableLiveData<List<ReviewItem>> = MutableLiveData()
@@ -61,8 +62,11 @@ class ReviewViewModel(
     fun setReviews(svcId: String) {
         viewModelScope.launch(Dispatchers.IO) {
             val data = serviceRepository.getServiceReviews(svcId)
+            val banList = userBanRepository.getBanList().toMutableList().apply {
+                remove(idPrefRepository.load())
+            }
 
-            _uiState.postValue(data)
+            _uiState.postValue(data.filter { it.userId !in banList })
         }
     }
 
@@ -108,7 +112,7 @@ class ReviewViewModel(
                     reviewRepository = container.reviewRepository,
                     userRepository = container.userRepository,
                     serviceRepository = container.serviceRepository,
-                    complaintRepository = container.complaintRepository
+                    userBanRepository = container.userBanRepository
                 )
             }
         }


### PR DESCRIPTION
## PR 체크리스트
다음 요구사항을 충족하는지 확인해주세요

- [x] 커밋메세지 규칙을 따릅니다.

## PR 유형
어떤 변경사항이 있는지 모두 체크해 주세요

- [x] 기능구현
- [ ] 버그픽스
- [x] 리팩토링
- [ ] 문서 변경
- [ ] 레이아웃
- [ ] 기타

## 변경사항 작성
<!-- 변경사항의 상세 정보를 작성해주세요. -->

-기능
신고하는 기능
신고 누적으로 인한 밴리스트 기능
밴리스트에 맞춰 UI 업데이트 기능
-설명
1. ComplaintEntity 수정
신고 테이블에 신고일시, 후기 아이디, 서비스 아이디 추가 완료

2. DB 저장 경로 변경
저장하는 방식을 신고당한 유저 ID 아래, 신고 일시 아래에 ComplaintEntity정보가 들어가도록 했다.

3. 밴리스트 레포지토리 생성 
밴 당한 유저 ID를 저장과 불러오기를 담당하는 레포지토리 생성

4. ComplaintRepository에서 현재 신고당한 유저가 밴리스트에 들어가야하는 체크 
현재까지 신고한 인원이 3명이상이라면 밴리스트에 추가

5. 신고로 인해 밴리스트에 들어간 유저가 있다면 바로 UI에 업데이트 
밴리스트와 서비의 후기 리스트를 비교하여 같은 유저ID를 가진 인원이 있다면 해당 후기는 제외

6. 밴리스트에 있는 유저는 그냥 자기거 볼 수 있도록 하는 기능
***용제님의 무시무시한 의도가 숨겨져있는 기능***
가져온 banList에서 자신의 이름만 쏙 빼서 밴 아닌 거처럼 하는 방법을 사용

## Merge 후 브랜치 삭제 여부
- [ ] 반영된 브랜치 삭제