### PR TITLE
[ Refactor ] : 후기 페이지 데이터 가져오는 방식 변경

### DIFF
--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/MainViewModel.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/MainViewModel.kt
@@ -1,0 +1,30 @@
+package com.wannabeinseoul.seoulpublicservice
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+
+class MainViewModel: ViewModel() {
+
+    private var selectedServiceId: String = ""
+
+    private val _applyFilter: MutableLiveData<Boolean> = MutableLiveData()
+    val applyFilter: LiveData<Boolean> get() = _applyFilter
+
+    private val _refreshReviewListState: MutableLiveData<Boolean> = MutableLiveData()
+    val refreshReviewListState: LiveData<Boolean> get() = _refreshReviewListState
+
+    fun setFilterState(flag: Boolean) {
+        _applyFilter.value = flag
+    }
+
+    fun setServiceId(id: String) {
+        selectedServiceId = id
+    }
+
+    fun getServiceId() = selectedServiceId
+
+    fun setReviewListState(flag: Boolean) {
+        _refreshReviewListState.value = flag
+    }
+}

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/MainViewModel.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/MainViewModel.kt
@@ -3,10 +3,12 @@ package com.wannabeinseoul.seoulpublicservice
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.wannabeinseoul.seoulpublicservice.dialog.review.ReviewItem
 
 class MainViewModel: ViewModel() {
 
     private var selectedServiceId: String = ""
+    private var currentReviewList: List<ReviewItem> = listOf()
 
     private val _applyFilter: MutableLiveData<Boolean> = MutableLiveData()
     val applyFilter: LiveData<Boolean> get() = _applyFilter
@@ -27,4 +29,10 @@ class MainViewModel: ViewModel() {
     fun setReviewListState(flag: Boolean) {
         _refreshReviewListState.value = flag
     }
+
+    fun setCurrentReviewList(list : List<ReviewItem>) {
+        currentReviewList = list
+    }
+
+    fun getCurrentReviewList(): List<ReviewItem> = currentReviewList
 }

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/detail/DetailFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/detail/DetailFragment.kt
@@ -14,6 +14,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.app.ActivityCompat
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.gms.location.FusedLocationProviderClient
@@ -22,6 +23,7 @@ import com.naver.maps.geometry.LatLng
 import com.naver.maps.map.*
 import com.naver.maps.map.overlay.Marker
 import com.naver.maps.map.util.MarkerIcons
+import com.wannabeinseoul.seoulpublicservice.MainViewModel
 import com.wannabeinseoul.seoulpublicservice.R
 import com.wannabeinseoul.seoulpublicservice.databases.ReservationEntity
 import com.wannabeinseoul.seoulpublicservice.databinding.FragmentDetailBinding
@@ -45,6 +47,8 @@ class DetailFragment : DialogFragment(), OnMapReadyCallback {       // Map 이�
     val binding get() = _binding!!
 
     private val viewModel: DetailViewModel by viewModels { DetailViewModel.factory }
+    private val mainViewModel: MainViewModel by activityViewModels()
+
     private var param1: String? = null
     private var textOpen = false    // 텍스트 뷰가 펼쳐져 있는지(false = 접힌 상태, true = 펼친 상태)
 
@@ -154,9 +158,8 @@ class DetailFragment : DialogFragment(), OnMapReadyCallback {       // Map 이�
             startActivity(Intent.createChooser(i, "링크 공유"))
         }
         it.tvDetailReviewMoveBtn.setOnClickListener {
-            val bottomSheet = ReviewFragment(param1!!) {
-                viewModel.setReviews(param1!!)
-            }
+            mainViewModel.setServiceId(param1!!)
+            val bottomSheet = ReviewFragment()
             bottomSheet.show(requireActivity().supportFragmentManager, bottomSheet.tag)
         }
     }
@@ -183,6 +186,10 @@ class DetailFragment : DialogFragment(), OnMapReadyCallback {       // Map 이�
         }
         vm.favoriteChanged.observe(viewLifecycleOwner) {
             favorite(it)
+        }
+
+        mainViewModel.refreshReviewListState.observe(viewLifecycleOwner) {
+            vm.setReviews(param1!!)
         }
     }
 

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/detail/DetailFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/detail/DetailFragment.kt
@@ -183,6 +183,7 @@ class DetailFragment : DialogFragment(), OnMapReadyCallback {       // Map Ïù¥Îè
         }
         vm.reviewUiState.observe(viewLifecycleOwner) {
             commentAdapter.submitList(it)
+            mainViewModel.setCurrentReviewList(it)
         }
         vm.favoriteChanged.observe(viewLifecycleOwner) {
             favorite(it)

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/dialog/filter/FilterFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/dialog/filter/FilterFragment.kt
@@ -2,6 +2,7 @@ package com.wannabeinseoul.seoulpublicservice.dialog.filter
 
 import android.app.Dialog
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -10,25 +11,24 @@ import android.view.animation.AnimationUtils
 import android.widget.Toast
 import androidx.core.view.isVisible
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import com.wannabeinseoul.seoulpublicservice.R
 import com.wannabeinseoul.seoulpublicservice.databinding.FragmentFilterBinding
 import com.google.android.material.chip.Chip
+import com.wannabeinseoul.seoulpublicservice.MainViewModel
 
-class FilterFragment(
-    private val onClickButton: () -> Unit
-) : DialogFragment() {
+class FilterFragment : DialogFragment() {
 
     companion object {
-        fun newInstance(onClickButton: () -> Unit) = FilterFragment(
-            onClickButton = onClickButton
-        )
+        fun newInstance() = FilterFragment()
     }
 
     private var _binding: FragmentFilterBinding? = null
     private val binding get() = _binding!!
 
     private val viewModel: FilterViewModel by viewModels { FilterViewModel.factory }
+    private val mainViewModel: MainViewModel by activityViewModels()
 
     private val filterOptions by lazy {
         listOf(
@@ -203,7 +203,7 @@ class FilterFragment(
 
         btnFilterApply.setOnClickListener {
             viewModel.save()
-            onClickButton.invoke()
+            mainViewModel.setFilterState(true)
             dismiss()
         }
 

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/dialog/review/ReviewFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/dialog/review/ReviewFragment.kt
@@ -93,7 +93,13 @@ class ReviewFragment: BottomSheetDialogFragment() {
     }
 
     private fun initViewModel() = with(viewModel) {
-        setReviews(svcId)
+        val storedReviewList = mainViewModel.getCurrentReviewList()
+        if (storedReviewList.isNotEmpty()) {
+            setReviewsByList(storedReviewList)
+        } else {
+            setReviews(svcId)
+        }
+
         checkWritableUser(svcId)
 
         uiState.observe(viewLifecycleOwner) {

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/dialog/review/ReviewFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/dialog/review/ReviewFragment.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.DialogInterface
 import android.os.Bundle
 import android.util.Log
+import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -12,31 +13,23 @@ import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
 import androidx.core.view.isVisible
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.wannabeinseoul.seoulpublicservice.MainViewModel
 import com.wannabeinseoul.seoulpublicservice.R
-import com.wannabeinseoul.seoulpublicservice.SeoulPublicServiceApplication
 import com.wannabeinseoul.seoulpublicservice.databinding.FragmentReviewBinding
 import com.wannabeinseoul.seoulpublicservice.dialog.complaint.ComplaintFragment
 
-class ReviewFragment(
-    private val svcId: String,
-    private val callback: () -> Unit
-) : BottomSheetDialogFragment() {
+class ReviewFragment: BottomSheetDialogFragment() {
 
     private var _binding: FragmentReviewBinding? = null
     private val binding get() = _binding!!
 
     private val viewModel: ReviewViewModel by viewModels { ReviewViewModel.factory }
-
-    private val app by lazy {
-        requireActivity().application as SeoulPublicServiceApplication
-    }
-    private val container by lazy {
-        app.container
-    }
+    private val mainViewModel: MainViewModel by activityViewModels()
 
     private val adapter: ReviewAdapter by lazy {
         ReviewAdapter(
@@ -46,6 +39,9 @@ class ReviewFragment(
         )
     }
 
+    private val svcId by lazy {
+        mainViewModel.getServiceId()
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -69,6 +65,8 @@ class ReviewFragment(
 
     private fun initView() = with(binding) {
 
+        isCancelable = true
+
         rvReviewList.adapter = adapter
 
         ivReviewSendBtn.setOnClickListener {
@@ -85,8 +83,12 @@ class ReviewFragment(
             false
         }
 
-        dialog?.setOnDismissListener {
-            callback()
+        dialog?.setOnKeyListener { _, keyCode, event ->
+            if (keyCode == KeyEvent.KEYCODE_BACK && event.action == KeyEvent.ACTION_UP) {
+                dismiss()
+                return@setOnKeyListener true
+            }
+            false
         }
     }
 
@@ -166,8 +168,7 @@ class ReviewFragment(
     }
 
     override fun onDismiss(dialog: DialogInterface) {
+        mainViewModel.setReviewListState(true)
         super.onDismiss(dialog)
-
-        dismissAllowingStateLoss()
     }
 }

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/dialog/review/ReviewViewModel.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/dialog/review/ReviewViewModel.kt
@@ -70,6 +70,10 @@ class ReviewViewModel(
         }
     }
 
+    fun setReviewsByList(list: List<ReviewItem>) {
+        _uiState.value = list
+    }
+
     fun reviseReview(svcId: String, review: String) {
         viewModelScope.launch(Dispatchers.IO) {
             val id = idPrefRepository.load()

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapFragment.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -12,6 +13,7 @@ import android.widget.Toast
 import androidx.core.app.ActivityCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.viewpager2.widget.ViewPager2.OnPageChangeCallback
 import com.naver.maps.geometry.LatLng
@@ -26,6 +28,7 @@ import com.naver.maps.map.overlay.Marker
 import com.naver.maps.map.overlay.Overlay
 import com.naver.maps.map.util.FusedLocationSource
 import com.naver.maps.map.util.MarkerIcons
+import com.wannabeinseoul.seoulpublicservice.MainViewModel
 import com.wannabeinseoul.seoulpublicservice.R
 import com.wannabeinseoul.seoulpublicservice.SeoulPublicServiceApplication
 import com.wannabeinseoul.seoulpublicservice.databinding.FragmentMapBinding
@@ -80,6 +83,7 @@ class MapFragment : Fragment(), OnMapReadyCallback {
             },
             moveDetailPage = { id ->
                 viewModel.changeVisible(false)
+                Log.d("MapFragment", "${mainViewModel.getServiceId()}")
                 activeMarkers.forEach { marker ->
                     marker.iconTintColor = requireContext().getColor(matchingColor[marker.tag] ?: R.color.gray)
                     marker.zIndex = 0
@@ -92,6 +96,7 @@ class MapFragment : Fragment(), OnMapReadyCallback {
     }
 
     private val viewModel: MapViewModel by viewModels { MapViewModel.factory }
+    private val mainViewModel: MainViewModel by activityViewModels()
 
     private val matchingColor = hashMapOf(
         "문화체험" to R.color.marker1_solid,
@@ -142,12 +147,7 @@ class MapFragment : Fragment(), OnMapReadyCallback {
                 marker.iconTintColor = requireContext().getColor(matchingColor[marker.tag] ?: R.color.gray)
                 marker.zIndex = 0
             }
-            val dialog = FilterFragment.newInstance(
-                onClickButton = {
-                    viewModel.loadSavedOptions()
-                    rvAdapter.submitList(app.container.filterPrefRepository.load().flatten())
-                }
-            )
+            val dialog = FilterFragment.newInstance()
             dialog.show(requireActivity().supportFragmentManager, "FilterFragment")
         }
 
@@ -231,6 +231,13 @@ class MapFragment : Fragment(), OnMapReadyCallback {
                         true
                     }
                 }
+            }
+        }
+
+        mainViewModel.applyFilter.observe(viewLifecycleOwner) {
+            if (it) {
+                viewModel.loadSavedOptions()
+                rvAdapter.submitList(app.container.filterPrefRepository.load().flatten())
             }
         }
     }

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapFragment.kt
@@ -15,6 +15,7 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
+import androidx.viewpager2.widget.ViewPager2
 import androidx.viewpager2.widget.ViewPager2.OnPageChangeCallback
 import com.naver.maps.geometry.LatLng
 import com.naver.maps.map.CameraAnimation
@@ -135,7 +136,12 @@ class MapFragment : Fragment(), OnMapReadyCallback {
 
     private fun initView() {
         binding.vpMapDetailInfo.adapter = adapter
-        binding.vpMapDetailInfo.registerOnPageChangeCallback(object : OnPageChangeCallback() {})
+        binding.vpMapDetailInfo.registerOnPageChangeCallback(object : OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                super.onPageSelected(position)
+                binding.tvMapInfoCount.text = "${position + 1}"
+            }
+        })
         binding.vpMapDetailInfo.offscreenPageLimit = 1
 
         binding.rvMapSelectedOption.adapter = rvAdapter
@@ -156,6 +162,12 @@ class MapFragment : Fragment(), OnMapReadyCallback {
         }
 
         viewModel.initMap()
+        mainViewModel.applyFilter.observe(viewLifecycleOwner) {
+            if (it) {
+                viewModel.loadSavedOptions()
+                rvAdapter.submitList(app.container.filterPrefRepository.load().flatten())
+            }
+        }
     }
 
     private fun initViewModel() = with(viewModel) {
@@ -181,7 +193,7 @@ class MapFragment : Fragment(), OnMapReadyCallback {
 
         updateData.observe(viewLifecycleOwner) { list ->
             adapter.submitList(list.toList())
-            binding.tvMapInfoCount.text = list.size.toString()
+            binding.tvMapInfoCount.text = "1"
         }
 
         moveToUrl.observe(viewLifecycleOwner) {
@@ -231,13 +243,6 @@ class MapFragment : Fragment(), OnMapReadyCallback {
                         true
                     }
                 }
-            }
-        }
-
-        mainViewModel.applyFilter.observe(viewLifecycleOwner) {
-            if (it) {
-                viewModel.loadSavedOptions()
-                rvAdapter.submitList(app.container.filterPrefRepository.load().flatten())
             }
         }
     }
@@ -293,7 +298,7 @@ class MapFragment : Fragment(), OnMapReadyCallback {
                 y ?: app.lastLocation?.latitude ?: 37.5666,
                 x ?: app.lastLocation?.longitude ?: 126.9782
             ),
-            15.0
+            14.5
         ).animate(CameraAnimation.Easing, 600)
 
         naverMap.moveCamera(cameraUpdate)

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapViewModel.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapViewModel.kt
@@ -95,7 +95,6 @@ class MapViewModel(
             if (readyMap && readyData) {
                 _canStart.postValue(true)
             }
-            checkCanDraw()
         }
     }
 
@@ -104,11 +103,6 @@ class MapViewModel(
         if (readyMap && readyData) {
             _canStart.postValue(true)
         }
-        checkCanDraw()
-    }
-
-    private fun checkCanDraw() {
-
     }
 
     fun saveService(id: String) {

--- a/app/src/main/res/drawable/background_white_with_f8496c_stroke.xml
+++ b/app/src/main/res/drawable/background_white_with_f8496c_stroke.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="@color/white"/>
+    <solid android:color="@color/selected_option_solid"/>
     <corners android:radius="4dp"/>
-    <stroke android:color="@color/point_color" android:width="1dp"/>
+    <stroke android:color="@color/selected_option_stroke" android:width="1dp"/>
 </shape>

--- a/app/src/main/res/drawable/ic_revise.xml
+++ b/app/src/main/res/drawable/ic_revise.xml
@@ -3,8 +3,8 @@
     android:height="24dp"
     android:viewportWidth="960"
     android:viewportHeight="960"
-    android:tint="?attr/colorControlNormal">
+    android:tint="@color/gray">
   <path
-      android:fillColor="@android:color/white"
+      android:fillColor="@color/gray"
       android:pathData="M482,800Q348,800 254,707Q160,614 160,480L160,473L96,537L40,481L200,321L360,481L304,537L240,473L240,480Q240,580 310.5,650Q381,720 482,720Q508,720 533,714Q558,708 582,696L642,756Q604,778 564,789Q524,800 482,800ZM760,639L600,479L656,423L720,487L720,480Q720,380 649.5,310Q579,240 478,240Q452,240 427,246Q402,252 378,264L318,204Q356,182 396,171Q436,160 478,160Q612,160 706,253Q800,346 800,480L800,487L864,423L920,479L760,639Z"/>
 </vector>

--- a/app/src/main/res/layout/fragment_detail.xml
+++ b/app/src/main/res/layout/fragment_detail.xml
@@ -457,7 +457,6 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/tv_detail_title_review" />
-
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_map.xml
+++ b/app/src/main/res/layout/fragment_map.xml
@@ -93,6 +93,93 @@
         app:layout_constraintTop_toBottomOf="@+id/tv_map_filter_btn" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:background="@drawable/background_select_region_layout"
+        android:padding="8dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/mv_naver">
+
+        <TextView
+            android:id="@+id/tv_map_marker1_description"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@drawable/corners_round"
+            android:backgroundTint="@color/marker1_solid"
+            android:paddingHorizontal="6dp"
+            android:text="문화체험"
+            android:textColor="@color/white"
+            android:textSize="12sp"
+            android:textStyle="bold"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_map_marker2_description"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:background="@drawable/corners_round"
+            android:backgroundTint="@color/marker2_solid"
+            android:paddingHorizontal="6dp"
+            android:text="공간시설"
+            android:textColor="@color/white"
+            android:textSize="12sp"
+            android:textStyle="bold"
+            app:layout_constraintStart_toStartOf="@+id/tv_map_marker1_description"
+            app:layout_constraintTop_toBottomOf="@+id/tv_map_marker1_description" />
+
+        <TextView
+            android:id="@+id/tv_map_marker3_description"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:background="@drawable/corners_round"
+            android:backgroundTint="@color/marker3_solid"
+            android:paddingHorizontal="6dp"
+            android:text="진료복지"
+            android:textColor="@color/white"
+            android:textSize="12sp"
+            android:textStyle="bold"
+            app:layout_constraintStart_toStartOf="@+id/tv_map_marker2_description"
+            app:layout_constraintTop_toBottomOf="@+id/tv_map_marker2_description" />
+
+        <TextView
+            android:id="@+id/tv_map_marker4_description"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:background="@drawable/corners_round"
+            android:backgroundTint="@color/marker4_solid"
+            android:paddingHorizontal="6dp"
+            android:text="체육시설"
+            android:textColor="@color/white"
+            android:textSize="12sp"
+            android:textStyle="bold"
+            app:layout_constraintStart_toStartOf="@+id/tv_map_marker3_description"
+            app:layout_constraintTop_toBottomOf="@+id/tv_map_marker3_description" />
+
+        <TextView
+            android:id="@+id/tv_map_marker5_description"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:background="@drawable/corners_round"
+            android:backgroundTint="@color/marker5_solid"
+            android:paddingHorizontal="6dp"
+            android:text="교육강좌"
+            android:textColor="@color/white"
+            android:textSize="12sp"
+            android:textStyle="bold"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/tv_map_marker4_description"
+            app:layout_constraintTop_toBottomOf="@+id/tv_map_marker4_description" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/cl_map_info_count"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/fragment_review.xml
+++ b/app/src/main/res/layout/fragment_review.xml
@@ -74,6 +74,7 @@
         android:maxLines="1"
         android:paddingHorizontal="8dp"
         android:textColorHint="@color/review_hint_text"
+        android:textColor="@color/total_text_color"
         android:textSize="14sp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/iv_review_send_btn"

--- a/app/src/main/res/layout/item_detail_comment.xml
+++ b/app/src/main/res/layout/item_detail_comment.xml
@@ -8,9 +8,10 @@
 
     <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/iv_comment_profile"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="0dp"
         android:adjustViewBounds="true"
+        app:layout_constraintDimensionRatio="1:1"
         app:layout_constraintBottom_toBottomOf="@+id/tv_comment_text"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="@+id/tv_comment_user"
@@ -53,9 +54,9 @@
     <com.google.android.material.divider.MaterialDivider
         android:id="@+id/materialDivider2"
         android:layout_width="0dp"
-        android:layout_height="0.5dp"
+        android:layout_height="1dp"
         android:layout_marginTop="10dp"
-        android:background="@color/black_gray"
+        app:dividerColor="@color/black_gray"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/item_map_info_window.xml
+++ b/app/src/main/res/layout/item_map_info_window.xml
@@ -40,7 +40,6 @@
         android:ellipsize="end"
         android:maxLines="2"
         android:text="잠실제3농구경기장"
-        android:textColor="@color/black"
         android:textSize="14sp"
         android:textStyle="bold"
         app:layout_constraintEnd_toEndOf="@+id/btn_map_info_reservation"

--- a/app/src/main/res/layout/item_selected_option.xml
+++ b/app/src/main/res/layout/item_selected_option.xml
@@ -14,7 +14,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="옵션"
-        android:textColor="@color/point_color"
+        android:textColor="@color/selected_option_text"
         android:textSize="14sp"
         android:textStyle="bold"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -11,7 +11,7 @@
     <color name="black_50">#60000000</color>
     <color name="point_color">#F8496C</color>
     <color name="pay">#FFCCCC</color>
-    <color name="black_gray">#828282</color>
+    <color name="black_gray">#232323</color>
     <color name="black_70">#70000000</color>
     <color name="total_background">#2B2B2B</color>
     <color name="total_text_color">#EFEFEF</color>
@@ -34,6 +34,9 @@
     <color name="material_divider_solid">#404040</color>
     <color name="review_user_name_text">#C5C5C5</color>
     <color name="review_hint_text">#C6C6C6</color>
+    <color name="selected_option_stroke">#00FFFFFF</color>
+    <color name="selected_option_solid">#6A6A6A</color>
+    <color name="selected_option_text">#EFEFEF</color>
 
     <color name="marker1_solid">#25B1FF</color>
     <color name="marker2_solid">#FFAC1C</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -11,7 +11,7 @@
     <color name="black_50">#60000000</color>
     <color name="point_color">#F8496C</color>
     <color name="pay">#FFCCCC</color>
-    <color name="black_gray">#828282</color>
+    <color name="black_gray">#F3F3F3</color>
     <color name="black_70">#70000000</color>
     <color name="total_background">#FFFFFF</color>
     <color name="total_text_color">#1A1A1A</color>
@@ -34,6 +34,9 @@
     <color name="material_divider_solid">#E8E8E8</color>
     <color name="review_user_name_text">#686868</color>
     <color name="review_hint_text">#555555</color>
+    <color name="selected_option_stroke">#F8496C</color>
+    <color name="selected_option_solid">#FFFFFF</color>
+    <color name="selected_option_text">#F8496C</color>
 
     <color name="marker1_solid">#25B1FF</color>
     <color name="marker2_solid">#FFAC1C</color>


### PR DESCRIPTION
## PR 체크리스트
다음 요구사항을 충족하는지 확인해주세요

- [x] 커밋메세지 규칙을 따릅니다.

## PR 유형
어떤 변경사항이 있는지 모두 체크해 주세요

- [ ] 기능구현
- [ ] 버그픽스
- [x] 리팩토링
- [ ] 문서 변경
- [ ] 레이아웃
- [ ] 기타

## 변경사항 작성
<!-- 변경사항의 상세 정보를 작성해주세요. -->

-기능
공유뷰모델을 사용한 후기 리스트 UI 노출
-설명
상세 페이지에서 후기 리스트를 띄울 때 파이어베이스 통신을 해서 가져온다.
그리고 가져온 값을 공유 뷰모델에 저장해놓는다.
더보기를 눌러 후기 페이지로 이동한다.
후기 페이지에서 후기 리스트를 띄울 때 공유 뷰모델에 저장된 후기 리스트를 가지고 와서 띄운다.(혹시나 몰라서 이전에 쓰던 함수도 쓸 수 있게 해놨다.)

속도가 엄청 빨라졌다.
깜빡이는 것도 없고 그냥 바로 UI에 뜨더라

## Merge 후 브랜치 삭제 여부
- [ ] 반영된 브랜치 삭제