### PR TITLE
Feat : 빈 뷰를 하나 만들고 터치시 et_search 포커스 해제와 키보드를 내리게 하는 기능 구현

### DIFF
--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/HomeFragment.kt
@@ -54,11 +54,7 @@ class HomeFragment : Fragment() {
         }
     }
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentHomeBinding.inflate(inflater, container, false)
         return binding.root
     }
@@ -169,9 +165,6 @@ class HomeFragment : Fragment() {
         setupBackPress()
         setupSearch()
         setupSearchHistory()
-        /*setupOverlayTouchListener()
-        setupSearchResultsTouchListener()
-        setupSearchHistoryTouchListener()*/
         setupRegionSelection()
         setupNotificationClick()
         setupBannerClick()
@@ -259,46 +252,28 @@ class HomeFragment : Fragment() {
         }
     }
 
+    @SuppressLint("ClickableViewAccessibility")
     private fun setupSearchHistory() {
         binding.etSearch.setOnFocusChangeListener { _, hasFocus ->
             if (hasFocus) {
                 viewModel.showSearchHistory()
+                binding.viewControlRvSearchResults.visibility = View.VISIBLE
             } else {
                 hideSearchHistory()
+                binding.viewControlRvSearchResults.visibility = View.GONE
             }
         }
-    }
 
-    /*@SuppressLint("ClickableViewAccessibility")
-    private fun setupOverlayTouchListener() {
-        binding.viewOverlay.setOnTouchListener { v, event ->
-            if (event.action == MotionEvent.ACTION_DOWN) {
-                // 검색창 밖 영역을 터치하면 키보드를 숨김
-                binding.etSearch.clearFocus()
-                hideSearchHistory()
-            }
+        // viewControlRvSearchResults가 터치될 때 호출되는 리스너 설정
+        binding.viewControlRvSearchResults.setOnTouchListener { _, _ ->
+            // viewControlRvSearchResults가 터치되면 EditText의 포커스를 해제, 키보드 숨기기
+            binding.etSearch.clearFocus()
+            hideKeyboard()
             true
         }
     }
 
-    @SuppressLint("ClickableViewAccessibility")
-    private fun setupSearchResultsTouchListener() {
-        binding.rvSearchResults.setOnTouchListener { v, event ->
-            if (event.action == MotionEvent.ACTION_DOWN) {
-                // 검색창 밖 영역을 터치하면 키보드를 숨김
-                binding.etSearch.clearFocus()
-                hideSearchHistory()
-            }
-            true
-        }
-    }
 
-    @SuppressLint("ClickableViewAccessibility")
-    private fun setupSearchHistoryTouchListener() {
-        binding.rvSearchHistory.setOnTouchListener { v, event ->
-            true
-        }
-    }*/
 
     private fun setupRegionSelection() {
         binding.clHomeSetRegion.setOnClickListener {

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -168,16 +168,6 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <View
-        android:id="@+id/view_overlay"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:background="@android:color/transparent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/layout_search" />
-
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rv_search_results"
         android:layout_width="match_parent"
@@ -189,6 +179,12 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/layout_search" />
+
+    <View
+        android:id="@+id/view_control_rv_search_results"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rv_search_history"
@@ -204,7 +200,6 @@
         app:layout_constraintEnd_toEndOf="@+id/layout_search"
         app:layout_constraintStart_toStartOf="@+id/layout_search"
         app:layout_constraintTop_toBottomOf="@+id/layout_search" />
-
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/cl_home_region_list"


### PR DESCRIPTION
## PR 체크리스트
다음 요구사항을 충족하는지 확인해주세요

- [x] 커밋메세지 규칙을 따릅니다.

## PR 유형
어떤 변경사항이 있는지 모두 체크해 주세요

- [x] 기능구현
- [x] 버그픽스
- [ ] 리팩토링
- [ ] 문서 변경
- [x] 레이아웃
- [ ] 기타

## 변경사항 작성
<!-- 변경사항의 상세 정보를 작성해주세요. -->

-기능
검색창 바깥 부분 터치시, 검색창 포커스를 해제하고 키보드를 내리는 기능 구현
-설명
화면 전체를 채우는 빈 뷰를 하나 만들고 터치시 검색창 포커스 해제와 키보드 내리는 기능(xml에서 View의 순서를 조절하여 저장된 검색어 리사이클러 뷰의 터치를 방해하지 않게 함)

## Merge 후 브랜치 삭제 여부
- [ ] 반영된 브랜치 삭제