### PR TITLE
[ Refactor ] : 이미지로딩방식, 캡션텍스트 조건, canStart, getServiceReviews 변경

### DIFF
--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firestore/ServiceRepository.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firestore/ServiceRepository.kt
@@ -51,7 +51,8 @@ class ServiceRepositoryImpl : ServiceRepository {
     }
 
     override suspend fun getServiceReviews(svcId: String): List<ReviewItem> {
-        getService(svcId)
+        if (!checkService(svcId)) fireStore.collection("service").document(svcId)
+            .set(ServiceEntity(svcId))
 
         val serviceReviewList =
             fireStore.collection("review").whereEqualTo("svcId", svcId).get().await()

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapDetailInfoAdapter.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapDetailInfoAdapter.kt
@@ -8,10 +8,10 @@ import androidx.core.text.HtmlCompat
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import coil.load
 import com.wannabeinseoul.seoulpublicservice.R
 import com.wannabeinseoul.seoulpublicservice.databinding.ItemMapInfoWindowBinding
 import com.wannabeinseoul.seoulpublicservice.pref.SavedPrefRepository
+import com.wannabeinseoul.seoulpublicservice.util.loadWithHolder
 
 class MapDetailInfoAdapter(
     private val saveService: (String) -> Unit,
@@ -90,7 +90,7 @@ class MapDetailInfoAdapter(
             } else {
                 ivMapInfoSaveServiceBtn.setImageResource(R.drawable.ic_save_empty)
             }
-            ivMapInfoPicture.load(item.imgurl)
+            ivMapInfoPicture.loadWithHolder(item.imgurl)
             tvMapInfoRegion.text = item.areanm
             tvMapInfoService.text =
                 HtmlCompat.fromHtml(item.svcnm, HtmlCompat.FROM_HTML_MODE_LEGACY)

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapFragment.kt
@@ -245,7 +245,7 @@ class MapFragment : Fragment(), OnMapReadyCallback {
                         matchingColor[it.value[0].maxclassnm] ?: R.color.gray
                     )
                     marker.tag = it.value[0].maxclassnm
-                    marker.captionText = it.value.size.toString()
+                    if (it.value.size > 1) marker.captionText = it.value.size.toString()
                     marker.setCaptionAligns(Align.Top)
                     marker.captionTextSize = 16f
                     marker.captionMinZoom = 13.0
@@ -311,7 +311,8 @@ class MapFragment : Fragment(), OnMapReadyCallback {
 
         moveCamera(
             fusedLocationSource?.lastLocation?.latitude,
-            fusedLocationSource?.lastLocation?.longitude
+            fusedLocationSource?.lastLocation?.longitude,
+            14.8
         )
 
 //        map.addOnLocationChangeListener { location ->
@@ -319,14 +320,14 @@ class MapFragment : Fragment(), OnMapReadyCallback {
 //        }
     }
 
-    private fun moveCamera(y: Double?, x: Double?) {
+    private fun moveCamera(y: Double?, x: Double?, zoom: Double = 15.0) {
         val location = app.fusedLocationSource?.lastLocation
         val cameraUpdate = CameraUpdate.scrollAndZoomTo(
             LatLng(
                 y ?: location?.latitude ?: 37.5666,
                 x ?: location?.longitude ?: 126.9782
             ),
-            15.0
+            zoom
         ).animate(CameraAnimation.Easing, 600)
 
         naverMap?.moveCamera(cameraUpdate)
@@ -378,6 +379,7 @@ class MapFragment : Fragment(), OnMapReadyCallback {
     override fun onPause() {
         super.onPause()
         binding.etMapSearch.setText("")
+        viewModel.offStart()
         mapView.onPause()
     }
 

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapFragment.kt
@@ -312,7 +312,7 @@ class MapFragment : Fragment(), OnMapReadyCallback {
         moveCamera(
             fusedLocationSource?.lastLocation?.latitude,
             fusedLocationSource?.lastLocation?.longitude,
-            14.8
+            14.5
         )
 
 //        map.addOnLocationChangeListener { location ->

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapViewModel.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapViewModel.kt
@@ -100,6 +100,10 @@ class MapViewModel(
 
     fun getSavedPrefRepository() = getSavedServiceUseCase()
 
+    fun offStart() {
+        _canStart.value = false
+    }
+
     companion object {
         /** 뷰모델팩토리에서 의존성주입을 해준다 */
         val factory = viewModelFactory {


### PR DESCRIPTION
## PR 체크리스트
다음 요구사항을 충족하는지 확인해주세요

- [x] 커밋메세지 규칙을 따릅니다.

## PR 유형
어떤 변경사항이 있는지 모두 체크해 주세요

- [x] 기능구현
- [x] 버그픽스
- [x] 리팩토링
- [ ] 문서 변경
- [ ] 레이아웃
- [ ] 기타

## 변경사항 작성
<!-- 변경사항의 상세 정보를 작성해주세요. -->

-기능
지도 페이지 기능 보완
-설명
지도페이지 상세정보창의 이미지로딩방식을 용제님이 만들고 보완해주신 loadWithHolder로 변경

마커에 달리는 캡션텍스트의 조건을 들어가는 데이터의 크기가 1보다 클때만 들어가게 했다. 다른 말로 하면 해당 좌표에서 제공되는 서비스가 1일 때는 캡션텍스트가 뜨지 않고 2부터 뜬다는 것이다.

canStart로 인해 앱이 튕기는 문제가 간혹 생겼었는데 이게 canStart의 value가 유지되고 있다가 생명주기상 다시 돌아와 옵저빙되면서 맵과 데이터가 준비되지 않았는데 코드를 실행하려는 것으로 판단해 onPause시에 해당 value를 false로 바꾸는 코드를 추가함

getServiceReviews 함수에서 getService 함수를 쓰고 있었는데 그럴 필요없이 그냥 Document 세팅만 하면 됐기에 그 쪽 코드만 복붙해서 가져왔다.(이로 인해 통신이 한번 줄었다. 200ms 이득!)

## Merge 후 브랜치 삭제 여부
- [x] 반영된 브랜치 삭제