### PR TITLE
[ Fix ] : 후기를 지웠을 때 서비스와 유저 Collection에서는 지워지지 않았던 문제 해결

### DIFF
--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firestore/ReviewRepository.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firestore/ReviewRepository.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.tasks.await
 interface ReviewRepository {
     fun addReview(reviewId: String, reviewInfo: ReviewEntity)
 
-    suspend fun reviseReview(id: String, svcId: String, review: String)
+    suspend fun reviseReview(reviewId: String, review: String)
 
     suspend fun deleteReview(reviewId: String)
 
@@ -25,12 +25,8 @@ class ReviewRepositoryImpl : ReviewRepository {
         fireStore.collection("review").document(reviewId).set(reviewInfo)
     }
 
-    override suspend fun reviseReview(id: String, svcId: String, review: String) {
-        val targetReview =
-            fireStore.collection("review").whereEqualTo("userId", id).whereEqualTo("svcId", svcId)
-                .get().await().toObjects(ReviewEntity::class.java)
-
-        fireStore.collection("review").document(targetReview[0].reviewId ?: "")
+    override suspend fun reviseReview(reviewId: String, review: String) {
+        fireStore.collection("review").document(reviewId)
             .update("content", review)
     }
 

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firestore/ServiceRepository.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firestore/ServiceRepository.kt
@@ -15,6 +15,11 @@ interface ServiceRepository {
         reviewId: String
     )
 
+    suspend fun deleteServiceReview(
+        svcId: String,
+        reviewId: String
+    )
+
     suspend fun getService(
         svcId: String
     ): ServiceEntity?
@@ -42,9 +47,15 @@ class ServiceRepositoryImpl : ServiceRepository {
             .update("reviewIdList", service?.reviewIdList.orEmpty().toMutableList() + reviewId)
     }
 
+    override suspend fun deleteServiceReview(svcId: String, reviewId: String) {
+        val service = getService(svcId)
+        fireStore.collection("service").document(svcId)
+            .update("reviewIdList", service?.reviewIdList.orEmpty().toMutableList() - reviewId)
+    }
+
     override suspend fun getService(svcId: String): ServiceEntity? {
         if (!checkService(svcId)) fireStore.collection("service").document(svcId)
-            .set(ServiceEntity(svcId))
+            .set(ServiceEntity(svcId)).await()
 
         return fireStore.collection("service").document(svcId).get().await()
             .toObject(ServiceEntity::class.java)

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firestore/UserRepository.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/databases/firestore/UserRepository.kt
@@ -33,6 +33,11 @@ interface UserRepository {
         reviewId: String
     )
 
+    suspend fun deleteUserReview(
+        id: String,
+        reviewId: String
+    )
+
     suspend fun getUser(
         id: String
     ): UserEntity?
@@ -70,6 +75,12 @@ class UserRepositoryImpl : UserRepository {
         val user = getUser(id)
         fireStore.collection("user").document(id)
             .update("reviewIdList", user?.reviewIdList.orEmpty().toMutableList() + reviewId)
+    }
+
+    override suspend fun deleteUserReview(id: String, reviewId: String) {
+        val user = getUser(id)
+        fireStore.collection("user").document(id)
+            .update("reviewIdList", user?.reviewIdList.orEmpty().toMutableList() - reviewId)
     }
 
     override suspend fun getUser(id: String): UserEntity? =

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/di/AppContainer.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/di/AppContainer.kt
@@ -216,7 +216,6 @@ class DefaultAppContainer(context: Context, getAppRowList: () -> List<Row>) : Ap
 
     override val reviseReviewUseCase by lazy {
         ReviseReviewUseCase(
-            idPrefRepository = idPrefRepository,
             reviewRepository = reviewRepository
         )
     }
@@ -244,7 +243,10 @@ class DefaultAppContainer(context: Context, getAppRowList: () -> List<Row>) : Ap
 
     override val deleteReviewUseCase by lazy {
         DeleteReviewUseCase(
-            reviewRepository = reviewRepository
+            reviewRepository = reviewRepository,
+            serviceRepository = serviceRepository,
+            userRepository = userRepository,
+            idPrefRepository = idPrefRepository
         )
     }
 

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/usecase/DeleteReviewUseCase.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/usecase/DeleteReviewUseCase.kt
@@ -1,12 +1,19 @@
 package com.wannabeinseoul.seoulpublicservice.usecase
 
 import com.wannabeinseoul.seoulpublicservice.databases.firestore.ReviewRepository
+import com.wannabeinseoul.seoulpublicservice.databases.firestore.ServiceRepository
+import com.wannabeinseoul.seoulpublicservice.databases.firestore.UserRepository
 import com.wannabeinseoul.seoulpublicservice.pref.IdPrefRepository
 
 class DeleteReviewUseCase(
-    private val reviewRepository: ReviewRepository
+    private val reviewRepository: ReviewRepository,
+    private val serviceRepository: ServiceRepository,
+    private val userRepository: UserRepository,
+    private val idPrefRepository: IdPrefRepository
 ) {
-    suspend operator fun invoke(reviewId: String) {
+    suspend operator fun invoke(svcId: String, reviewId: String) {
         reviewRepository.deleteReview(reviewId)
+        serviceRepository.deleteServiceReview(svcId, reviewId)
+        userRepository.deleteUserReview(idPrefRepository.load(), reviewId)
     }
 }

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/usecase/ReviseReviewUseCase.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/usecase/ReviseReviewUseCase.kt
@@ -1,15 +1,11 @@
 package com.wannabeinseoul.seoulpublicservice.usecase
 
 import com.wannabeinseoul.seoulpublicservice.databases.firestore.ReviewRepository
-import com.wannabeinseoul.seoulpublicservice.pref.IdPrefRepository
 
 class ReviseReviewUseCase(
-    private val idPrefRepository: IdPrefRepository,
     private val reviewRepository: ReviewRepository
 ) {
-    suspend operator fun invoke(svcId: String, review: String) {
-        val id = idPrefRepository.load()
-
-        reviewRepository.reviseReview(id, svcId, review)
+    suspend operator fun invoke(reviewId: String, review: String) {
+        reviewRepository.reviseReview(reviewId, review)
     }
 }


### PR DESCRIPTION
## PR 체크리스트
다음 요구사항을 충족하는지 확인해주세요

- [x] 커밋메세지 규칙을 따릅니다.

## PR 유형
어떤 변경사항이 있는지 모두 체크해 주세요

- [x] 기능구현
- [x] 버그픽스
- [ ] 리팩토링
- [ ] 문서 변경
- [ ] 레이아웃
- [ ] 기타

## 변경사항 작성
<!-- 변경사항의 상세 정보를 작성해주세요. -->

-기능
<!!!작성부분!!!>
-설명
후기를 추가할 때는 후기, 서비스, 유저 Collection 모두에 reviewId를 추가했는데 후기를 삭제할 때는 후기 Collection에서만 지워서 서비스, 유저 Collection에는 이미 삭제된 reviewId가 계속 쌓이고 있음을 DB를 보다가 알게 되었다. 
그래서 추가했을 때와 동일하게 후기, 서비스, 유저 Collection에서 해당 reviewId를 삭제하도록 코드를 추가함

## Merge 후 브랜치 삭제 여부
- [x] 반영된 브랜치 삭제