### PR TITLE
[ Fix ] : 앱 첫 실행시 카테고리 버튼을 눌렀을 때 바로 관심지역 선택 액티비티로 이동시키기

### DIFF
--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/CultureEventFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/CultureEventFragment.kt
@@ -23,7 +23,7 @@ class CultureEventFragment : Fragment() {
     private val regionPrefRepository by lazy { (requireActivity().application as SeoulPublicServiceApplication).container.regionPrefRepository }
     private val dbMemoryRepository by lazy { (requireActivity().application as SeoulPublicServiceApplication).container.dbMemoryRepository }
     private val mainViewModel: MainViewModel by activityViewModels()
-    private val adapter by lazy { ItemAdapter(regionPrefRepository, "문화체험") }
+    private val adapter by lazy { ItemAdapter(regionPrefRepository, "문화체험") { mainViewModel.moveSelectRegions(it) } }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         // Inflate the layout for this fragment

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/EducationFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/EducationFragment.kt
@@ -23,7 +23,7 @@ class EducationFragment : Fragment() {
     private val regionPrefRepository by lazy { (requireActivity().application as SeoulPublicServiceApplication).container.regionPrefRepository }
     private val dbMemoryRepository by lazy { (requireActivity().application as SeoulPublicServiceApplication).container.dbMemoryRepository }
     private val mainViewModel: MainViewModel by activityViewModels()
-    private val adapter by lazy { ItemAdapter(regionPrefRepository, "교육강좌") }
+    private val adapter by lazy { ItemAdapter(regionPrefRepository, "교육강좌") { mainViewModel.moveSelectRegions(it) } }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         // Inflate the layout for this fragment

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/FacilityFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/FacilityFragment.kt
@@ -23,7 +23,7 @@ class FacilityFragment : Fragment() {
     private val regionPrefRepository by lazy { (requireActivity().application as SeoulPublicServiceApplication).container.regionPrefRepository }
     private val dbMemoryRepository by lazy { (requireActivity().application as SeoulPublicServiceApplication).container.dbMemoryRepository }
     private val mainViewModel: MainViewModel by activityViewModels()
-    private val adapter by lazy { ItemAdapter(regionPrefRepository, "체육시설") }
+    private val adapter by lazy { ItemAdapter(regionPrefRepository, "체육시설") { mainViewModel.moveSelectRegions(it) } }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         // Inflate the layout for this fragment

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/FacilityRentFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/FacilityRentFragment.kt
@@ -23,7 +23,7 @@ class FacilityRentFragment : Fragment() {
     private val regionPrefRepository by lazy { (requireActivity().application as SeoulPublicServiceApplication).container.regionPrefRepository }
     private val dbMemoryRepository by lazy { (requireActivity().application as SeoulPublicServiceApplication).container.dbMemoryRepository }
     private val mainViewModel: MainViewModel by activityViewModels()
-    private val adapter by lazy { ItemAdapter(regionPrefRepository, "공간시설") }
+    private val adapter by lazy { ItemAdapter(regionPrefRepository, "공간시설") { mainViewModel.moveSelectRegions(it) } }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         // Inflate the layout for this fragment

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/HomeFragment.kt
@@ -99,6 +99,13 @@ class HomeFragment : Fragment() {
             }
         }
 
+        mainViewModel.moveSelectRegions.observe(viewLifecycleOwner) {
+            if (it) {
+                val intent = Intent(context, InterestRegionSelectActivity::class.java)
+                resultLauncher.launch(intent)
+            }
+        }
+
         // HomeViewModel의 LiveData를 관찰하여 UI를 업데이트
         with(homeViewModel) {
             updateSelectedRegions.observe(viewLifecycleOwner) { selectedRegions ->

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/MedicalFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/MedicalFragment.kt
@@ -23,7 +23,7 @@ class MedicalFragment : Fragment() {
     private val regionPrefRepository by lazy { (requireActivity().application as SeoulPublicServiceApplication).container.regionPrefRepository }
     private val dbMemoryRepository by lazy { (requireActivity().application as SeoulPublicServiceApplication).container.dbMemoryRepository }
     private val mainViewModel: MainViewModel by activityViewModels()
-    private val adapter by lazy { ItemAdapter(regionPrefRepository, "진료복지") }
+    private val adapter by lazy { ItemAdapter(regionPrefRepository, "진료복지") { mainViewModel.moveSelectRegions(it) } }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         // Inflate the layout for this fragment

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/main/MainViewModel.kt
@@ -26,6 +26,9 @@ class MainViewModel: ViewModel() {
     private val _selectRegion: MutableLiveData<String> = MutableLiveData()
     val selectRegion: LiveData<String> get() = _selectRegion
 
+    private val _moveSelectRegions: MutableLiveData<Boolean> = MutableLiveData()
+    val moveSelectRegions: LiveData<Boolean> get() = _moveSelectRegions
+
     fun setFilterState(flag: Boolean) {
         _applyFilter.value = flag
     }
@@ -52,5 +55,9 @@ class MainViewModel: ViewModel() {
 
     fun setRegion(region: String) {
         _selectRegion.value = region
+    }
+
+    fun moveSelectRegions(flag: Boolean) {
+        _moveSelectRegions.value = flag
     }
 }

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/main/adapter/ItemAdapter.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/main/adapter/ItemAdapter.kt
@@ -17,7 +17,8 @@ import com.wannabeinseoul.seoulpublicservice.ui.category.CategoryActivity
 
 class ItemAdapter(
     private val regionPrefRepository: RegionPrefRepository,
-    private val maxClass: String
+    private val maxClass: String,
+    private val moveReselect: (Boolean) -> Unit
 ) : ListAdapter<Item, ItemAdapter.ItemViewHolder>(object : DiffUtil.ItemCallback<Item>() {
     override fun areItemsTheSame(oldItem: Item, newItem: Item): Boolean {
         return oldItem.name == newItem.name
@@ -30,7 +31,7 @@ class ItemAdapter(
 }) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ItemViewHolder {
         val binding = ItemHomeBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return ItemViewHolder(binding)
+        return ItemViewHolder(binding, moveReselect)
     }
 
     override fun onBindViewHolder(holder: ItemViewHolder, position: Int) {
@@ -41,7 +42,7 @@ class ItemAdapter(
         return currentList.size
     }
 
-    inner class ItemViewHolder(val binding: ItemHomeBinding) : RecyclerView.ViewHolder(binding.root) {
+    inner class ItemViewHolder(val binding: ItemHomeBinding, private val moveReselect: (Boolean) -> Unit) : RecyclerView.ViewHolder(binding.root) {
         fun bind(item: Item) = with(binding) {
             ivIcon.setImageResource(item.icon)
             tvName.text = item.name
@@ -60,6 +61,7 @@ class ItemAdapter(
                 itemView.setOnClickListener {
                     if (regionPrefRepository.loadSelectedRegion() == "지역선택") {
                         Toast.makeText(it.context, "관심지역을 먼저 선택해주세요.", Toast.LENGTH_SHORT).show()
+                        moveReselect(true)
                     } else {
                         // 아이콘의 배경색과 색상을 변경
                         setClickedIconColor()


### PR DESCRIPTION
## PR 체크리스트
다음 요구사항을 충족하는지 확인해주세요

- [x] 커밋메세지 규칙을 따릅니다.

## PR 유형
어떤 변경사항이 있는지 모두 체크해 주세요

- [x] 기능구현
- [ ] 버그픽스
- [ ] 리팩토링
- [ ] 문서 변경
- [ ] 레이아웃
- [x] 기타

## 변경사항 작성

-기능
앱 첫 실행시 카테고리 버튼을 눌렀을 때 바로 관심지역 선택 액티비티로 이동

-설명
신성휘 튜터님의 피드백 적용
토스트 메세지는 그대로 두고 관심지역 선택 액티비티 이동 기능만 추가
ItemAdapter에서 고차함수 써서 각각의 프래그먼트로 Boolean값을 빼고 그 값을 공유뷰모델(MainViewModel)에 저장한 다음 HomeFragment에서 옵저빙되면 바로 액티비티를 launch시키도록 함

## Merge 후 브랜치 보존 여부
(합친 브랜치는 삭제하는 것을 기본값으로 합니다. 브랜치를 유지할 필요가 있는 경우에 체크해주시기 바랍니다.)

- [ ] 반영된 브랜치 보존