### PR TITLE
[ Fix ] : 마커 정보창 저장 기능 오류 개선

### DIFF
--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/pref/SavedPrefRepository.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/pref/SavedPrefRepository.kt
@@ -58,7 +58,7 @@ class SavedPrefRepositoryImpl(context: Context) : SavedPrefRepository {
     override fun getSvcidList(): List<String> = savedSvcidListLiveData.value!!
 
     override fun setSvcidList(list: List<String>) {
-        _savedSvcidList.postValue(list)
+        _savedSvcidList.value = list
     }
 
     override fun clear() = setSvcidList(emptyList())

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapDetailInfoAdapter.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapDetailInfoAdapter.kt
@@ -120,12 +120,13 @@ class MapDetailInfoAdapter(
             }
 
             binding.ivMapInfoSaveServiceBtn.setOnClickListener {
-                saveService(item.svcid)
-                if (savedPrefRepository.contains(item.svcid)) {
-                    ivMapInfoSaveServiceBtn.setImageResource(R.drawable.ic_save_fill)
-                    ivMapInfoSaveServiceBtn.drawable.setTint(Color.parseColor("#F8496C"))
-                } else {
-                    ivMapInfoSaveServiceBtn.setImageResource(R.drawable.ic_save_empty)
+                saveService(item.svcid).let {
+                    if (savedPrefRepository.contains(item.svcid)) {
+                        ivMapInfoSaveServiceBtn.setImageResource(R.drawable.ic_save_fill)
+                        ivMapInfoSaveServiceBtn.drawable.setTint(Color.parseColor("#F8496C"))
+                    } else {
+                        ivMapInfoSaveServiceBtn.setImageResource(R.drawable.ic_save_empty)
+                    }
                 }
             }
 

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapFragment.kt
@@ -229,6 +229,7 @@ class MapFragment : Fragment(), OnMapReadyCallback {
         viewModel.setServiceData()
 
         updateData.observe(viewLifecycleOwner) { list ->
+            adapter.submitList(emptyList())
             adapter.submitList(list.toList())
             binding.tvMapInfoCount.text = "1"
         }


### PR DESCRIPTION
## PR 체크리스트
다음 요구사항을 충족하는지 확인해주세요

- [x] 커밋메세지 규칙을 따릅니다.

## PR 유형
어떤 변경사항이 있는지 모두 체크해 주세요

- [ ] 기능구현
- [x] 버그픽스
- [ ] 리팩토링
- [ ] 문서 변경
- [ ] 레이아웃
- [ ] 기타

## 변경사항 작성

-기능
마커 정보창 저장 기능 정상화

-설명
프로젝트 정리하면서 다시 기능을 작동해보고 있었는데 마커 정보창에서 저장 버튼을 누르고 상세 페이지와 마이페이지를 갔을 때 반영되지 않는 걸 확인

찾은 이유는 두 가지
1) 서비스 아이디를 저장해놓는 savedSvcidList에서 postValue를 사용하여 값을 업데이트하다보니 호출하는 쪽에서는 아직 반영되지 않은 문제
2) submitList를 할 때 같은 서비스 ID를 가지고 있는지로 DiffUtil 클래스가 동작하는데 마커의 정보창을 누르고 정보창을 닫은 다음 다시 동일한 마커를 누르면 같은 서비스 ID들로 이루어져 있기 때문에 변화가 적용되지 않는 문제

해결한 방법
1) postValue를 setValue로 변경(사용하는데가 백그라운드인데가 없어서 에러X) 
2) 마커 정보창을 띄울 때 먼저 빈리스트를 넣어준 다음 업데이트할 리스트를 넣는 방식으로 변경

## Merge 후 브랜치 보존 여부
(합친 브랜치는 삭제하는 것을 기본값으로 합니다. 브랜치를 유지할 필요가 있는 경우에 체크해주시기 바랍니다.)

- [ ] 반영된 브랜치 보존