### PR TITLE
[ Feat ] : WorkManager를 이용한 주기적인 알림 업데이트(1차 버전)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -91,6 +91,8 @@ dependencies {
 
     implementation("com.google.firebase:firebase-firestore-ktx:24.10.3")
 
+    implementation("androidx.work:work-runtime-ktx:2.9.0")
+
     //새로고침 관련 라이브러리
     implementation ("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
 }

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/pref/SavedPrefRepository.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/pref/SavedPrefRepository.kt
@@ -58,7 +58,7 @@ class SavedPrefRepositoryImpl(context: Context) : SavedPrefRepository {
     override fun getSvcidList(): List<String> = savedSvcidListLiveData.value!!
 
     override fun setSvcidList(list: List<String>) {
-        _savedSvcidList.postValue(list)
+        _savedSvcidList.value = list
     }
 
     override fun clear() = setSvcidList(emptyList())

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/service/NotificationWorker.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/service/NotificationWorker.kt
@@ -1,0 +1,102 @@
+package com.wannabeinseoul.seoulpublicservice.service
+
+import android.content.Context
+import android.util.Log
+import androidx.work.CoroutineWorker
+import androidx.work.Data
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.google.gson.Gson
+import com.wannabeinseoul.seoulpublicservice.SeoulPublicServiceApplication
+import kotlinx.coroutines.delay
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+class NotificationWorker(
+    appContext: Context,
+    params: WorkerParameters
+) : CoroutineWorker(appContext, params) {
+
+    override suspend fun doWork(): Result {
+        return try {
+            val container = (applicationContext as SeoulPublicServiceApplication).container
+            val savedList = getSvcIdList()
+            val database = container.dbMemoryRepository
+            val savedServiceList = savedList.map { database.findBySvcid(it) }
+
+            val datePattern = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+            val datePattern2 = DateTimeFormatter.ofPattern("yyyy-MM-dd HH")
+            val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.S")
+
+            // 예약 시작까지 하루 남은 서비스의 개수
+            val list = savedServiceList.filter {
+                datePattern2.format(
+                    LocalDateTime.parse(
+                        it?.RCPTBGNDT,
+                        formatter
+                    )
+                ) >= datePattern2.format(
+                    LocalDateTime.now().plusDays(1)
+                ) && datePattern.format(
+                    LocalDateTime.parse(
+                        it?.RCPTBGNDT,
+                        formatter
+                    )
+                ) == datePattern.format(
+                    LocalDateTime.now().plusDays(1)
+                )
+            }.size
+
+            // 예약 마감까지 하루 남은 서비스의 개수
+            val list2 = savedServiceList.filter {
+                datePattern2.format(
+                    LocalDateTime.parse(
+                        it?.RCPTENDDT,
+                        formatter
+                    )
+                ) >= datePattern2.format(
+                    LocalDateTime.now().plusDays(1)
+                ) && datePattern.format(
+                    LocalDateTime.parse(
+                        it?.RCPTENDDT,
+                        formatter
+                    )
+                ) == datePattern.format(
+                    LocalDateTime.now().plusDays(1)
+                )
+            }.size
+
+            // 예약 시작한 서비스의 개수
+            val list3 = savedServiceList.filter {
+                datePattern.format(
+                    LocalDateTime.parse(
+                        it?.RCPTBGNDT,
+                        formatter
+                    )
+                ) == datePattern.format(
+                    LocalDateTime.now()
+                )
+            }.size
+
+            val outputData: Data = Data.Builder()
+                .putBoolean("result", (list != 0 || list2 != 0 || list3 != 0))
+                .build()
+
+            setProgress(outputData)
+            delay(1000)
+            Result.success()
+        } catch (throwable: Throwable) {
+            Result.failure()
+        }
+    }
+
+    private val pref =
+        appContext.getSharedPreferences("SavedPrefRepository", Context.MODE_PRIVATE)
+    private val gson = Gson()
+
+    private val keySvcidList = "keySvcidList"
+    private fun getSvcIdList(): List<String> {
+        val json = pref.getString(keySvcidList, null) ?: return emptyList()
+        return gson.fromJson(json, Array<String>::class.java).toList()
+    }
+}

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapDetailInfoAdapter.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapDetailInfoAdapter.kt
@@ -120,12 +120,13 @@ class MapDetailInfoAdapter(
             }
 
             binding.ivMapInfoSaveServiceBtn.setOnClickListener {
-                saveService(item.svcid)
-                if (savedPrefRepository.contains(item.svcid)) {
-                    ivMapInfoSaveServiceBtn.setImageResource(R.drawable.ic_save_fill)
-                    ivMapInfoSaveServiceBtn.drawable.setTint(Color.parseColor("#F8496C"))
-                } else {
-                    ivMapInfoSaveServiceBtn.setImageResource(R.drawable.ic_save_empty)
+                saveService(item.svcid).let {
+                    if (savedPrefRepository.contains(item.svcid)) {
+                        ivMapInfoSaveServiceBtn.setImageResource(R.drawable.ic_save_fill)
+                        ivMapInfoSaveServiceBtn.drawable.setTint(Color.parseColor("#F8496C"))
+                    } else {
+                        ivMapInfoSaveServiceBtn.setImageResource(R.drawable.ic_save_empty)
+                    }
                 }
             }
 

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapFragment.kt
@@ -229,6 +229,7 @@ class MapFragment : Fragment(), OnMapReadyCallback {
         viewModel.setServiceData()
 
         updateData.observe(viewLifecycleOwner) { list ->
+            adapter.submitList(emptyList())
             adapter.submitList(list.toList())
             binding.tvMapInfoCount.text = "1"
         }

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/notifications/NotificationsViewModel.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/notifications/NotificationsViewModel.kt
@@ -26,6 +26,7 @@ class NotificationsViewModel(
     fun updateUiState() {
         viewModelScope.launch(Dispatchers.IO) {
             val datePattern = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+            val datePattern2 = DateTimeFormatter.ofPattern("yyyy-MM-dd HH")
             val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.S")
 
             val savedServiceList = savedPrefRepository.getSvcidList().map {
@@ -34,9 +35,21 @@ class NotificationsViewModel(
 
             // 예약 시작까지 하루 남은 서비스의 개수
             val list = savedServiceList.filter {
-                datePattern.format(LocalDateTime.parse(it.RCPTBGNDT, formatter)) > datePattern.format(
-                    LocalDateTime.now()) && datePattern.format(LocalDateTime.parse(it.RCPTBGNDT, formatter)) < datePattern.format(
-                    LocalDateTime.now().plusDays(2))
+                datePattern2.format(
+                    LocalDateTime.parse(
+                        it.RCPTBGNDT,
+                        formatter
+                    )
+                ) >= datePattern2.format(
+                    LocalDateTime.now().plusDays(1)
+                ) && datePattern.format(
+                    LocalDateTime.parse(
+                        it.RCPTBGNDT,
+                        formatter
+                    )
+                ) == datePattern.format(
+                    LocalDateTime.now().plusDays(1)
+                )
             }.map {
                 NotificationInfo(
                     it.SVCID,
@@ -48,9 +61,21 @@ class NotificationsViewModel(
 
             // 예약 마감까지 하루 남은 서비스의 개수
             val list2 = savedServiceList.filter {
-                datePattern.format(LocalDateTime.parse(it.RCPTENDDT, formatter)) < datePattern.format(
-                    LocalDateTime.now()) && datePattern.format(LocalDateTime.parse(it.RCPTENDDT, formatter)) > datePattern.format(
-                    LocalDateTime.now().minusDays(2))
+                datePattern2.format(
+                    LocalDateTime.parse(
+                        it.RCPTENDDT,
+                        formatter
+                    )
+                ) >= datePattern2.format(
+                    LocalDateTime.now().plusDays(1)
+                ) && datePattern.format(
+                    LocalDateTime.parse(
+                        it.RCPTENDDT,
+                        formatter
+                    )
+                ) == datePattern.format(
+                    LocalDateTime.now().plusDays(1)
+                )
             }.map {
                 NotificationInfo(
                     it.SVCID,
@@ -62,8 +87,14 @@ class NotificationsViewModel(
 
             // 예약 가능한 서비스의 개수
             val list3 = savedServiceList.filter {
-                datePattern.format(LocalDateTime.parse(it.RCPTBGNDT, formatter)) == datePattern.format(
-                    LocalDateTime.now())
+                datePattern.format(
+                    LocalDateTime.parse(
+                        it.RCPTBGNDT,
+                        formatter
+                    )
+                ) == datePattern.format(
+                    LocalDateTime.now()
+                )
             }.map {
                 NotificationInfo(
                     it.SVCID,


### PR DESCRIPTION
## PR 체크리스트
다음 요구사항을 충족하는지 확인해주세요

- [x] 커밋메세지 규칙을 따릅니다.

## PR 유형
어떤 변경사항이 있는지 모두 체크해 주세요

- [x] 기능구현
- [ ] 버그픽스
- [x] 리팩토링
- [ ] 문서 변경
- [ ] 레이아웃
- [ ] 기타

## 변경사항 작성

-기능
주기적인 알림 UI 업데이트

-설명
이전에는 그냥 함수호출만으로 앱 실행 시 최초 한번 알림 조건에 맞는 저장한 공공서비스가 있다면 UI를 업데이트하도록 했었다.

이번에는 WorkManager를 이용해서 한번 함수를 호출하면 1시간에 한번씩 저장한 공공서비스 목록을 확인해서 조건에 맞는 공공서비스가 있다면 주기적으로 UI를 업데이트하도록 보완해 구현했다.

이전에 뷰모델에 있던 조건식은 다 CoroutineWorker 클래스로 옮겨졌고 WorkManager에 등록하는 부분은 뷰모델에 있다.

흐름은 다음과 같다. 
작업(Worker)에 변화가 생기는 경우를 뷰모델에서 옵저빙하다가 체크가 되면 이를 라이브데이터에 넣어 HomeFragment에서 옵저빙해 UI를 업데이트한다. 이게 가능한 이유는 Worker에 대한 값이 라이브데이터로 넘어오기 때문이다.

추가적으로 이전의 조건식은 약간 빈틈이 있어서 조건식을 수정했다. 그래서 알림 페이지 내의 리사이클러뷰 구성하는 부분의 조건식도 동일하게 수정했다.

 관련된 내용이 궁금하다면 제 블로그로...ㅎㅎ

 이후 계획)
 이제는 조건에 맞는 공공서비스가 있는 경우 실제 Notification을 띄워주는 걸 해보려고 한다.
 누르면 앱이 실행되도록..!!

## Merge 후 브랜치 보존 여부
(합친 브랜치는 삭제하는 것을 기본값으로 합니다. 브랜치를 유지할 필요가 있는 경우에 체크해주시기 바랍니다.)

- [ ] 반영된 브랜치 보존