### PR TITLE
[ Fix ] : 저장 기능의 문제점(해결)

### DIFF
--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/pref/SavedPrefRepository.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/pref/SavedPrefRepository.kt
@@ -11,6 +11,7 @@ private const val JJTAG = "jj-SavedPrefRepository"
 interface SavedPrefRepository {
     fun getSvcidList(): List<String>
     fun setSvcidList(list: List<String>)
+    fun setSvcidListForSynchronization(list: List<String>)
     fun clear()
     fun addSvcidList(svcidList: List<String>)
     fun addSvcid(svcid: String)
@@ -59,6 +60,10 @@ class SavedPrefRepositoryImpl(context: Context) : SavedPrefRepository {
 
     override fun setSvcidList(list: List<String>) {
         _savedSvcidList.value = list
+    }
+
+    override fun setSvcidListForSynchronization(list: List<String>) {
+        _savedSvcidList.postValue(list)
     }
 
     override fun clear() = setSvcidList(emptyList())

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/category/CategoryFragment2.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/category/CategoryFragment2.kt
@@ -1,0 +1,222 @@
+package com.wannabeinseoul.seoulpublicservice.ui.category
+
+import android.app.Dialog
+import android.content.Context
+import android.graphics.Color
+import android.os.Bundle
+import android.os.Handler
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
+import android.widget.Toast
+import androidx.core.view.isInvisible
+import androidx.core.view.isVisible
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.wannabeinseoul.seoulpublicservice.R
+import com.wannabeinseoul.seoulpublicservice.databinding.FragmentCategoryBinding
+import com.wannabeinseoul.seoulpublicservice.ui.detail.DetailCloseInterface
+import com.wannabeinseoul.seoulpublicservice.ui.detail.DetailFragment
+import com.wannabeinseoul.seoulpublicservice.ui.main.MainViewModel
+
+private const val CATEGORY_PARAM1 = "category_param1"
+private const val CATEGORY_PARAM2 = "category_param2"
+
+//ctrl alt o
+class CategoryFragment2 : DialogFragment() {
+
+    private var _binding: FragmentCategoryBinding? = null
+    private val binding get()= _binding!!
+
+    private val viewModel: CategoryViewModel by viewModels { CategoryViewModel.factory }
+    private val mainViewModel: MainViewModel by activityViewModels { MainViewModel.factory }
+
+    private val adapter by lazy {
+        CategoryAdapter {}
+    }
+
+    private var payment: String = ""    // 요금이 무료인지 또는 ""인지
+    private var serviceState: List<String> = listOf() // 서비스 상태가 가능인지 아니면 불가능인지
+    private var search = "" // 검색어
+
+    private val scrollListener = object : RecyclerView.OnScrollListener() {
+        override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
+            super.onScrollStateChanged(recyclerView, newState)
+
+            if (!recyclerView.canScrollVertically(-1)) {
+                // 리스트가 최상단에 도달했을 때
+                binding.fabRecentFloating.visibility = View.GONE
+            } else if (!recyclerView.canScrollVertically(1)) {
+                // 리스트가 최하단에 도달했을 때
+                binding.fabRecentFloating.visibility = View.VISIBLE
+            } else {
+                // 리스트가 중간에 있을 때
+                binding.fabRecentFloating.visibility = View.VISIBLE
+            }
+        }
+    }
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentCategoryBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?) =
+        Dialog(requireContext(), R.style.DetailTransparent)
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.root.setOnClickListener {
+            hideKeyboard()
+        }
+        initView()
+        initViewModel()
+
+        categoryClick()
+
+        binding.reCategory.addOnScrollListener(scrollListener)
+
+        // FloatingActionButton 클릭 이벤트 처리
+        binding.fabRecentFloating.setOnClickListener {
+            binding.reCategory.smoothScrollToPosition(0)
+        }
+    }
+
+    private fun initView() {
+        binding.reCategory.adapter = adapter
+
+        val category =
+            if (arguments?.getString(CATEGORY_PARAM1) == "서북병원") "병원" else arguments?.getString(CATEGORY_PARAM1)
+        val region = arguments?.getString(CATEGORY_PARAM2)
+
+        binding.tvCtTitle.text = if (region == "") "전체 - $category" else "$region - $category"
+
+        //라이브데이터에 리스트를 넣어놈.
+        viewModel.updateList(region ?: "", category ?: "")
+
+        binding.ivCategoryBack.setOnClickListener {
+            dismiss()
+        }
+
+        // 무료 버튼 클릭 시
+        binding.tvCtFree.setOnClickListener {
+            categoryFilter("pay")
+        }
+        // 예약가능 버튼 클릭 시
+        binding.tvCtIsReservationAvailable.setOnClickListener {
+            categoryFilter("svc")
+        }
+        // 검색기능 추가
+        binding.etCategorySearch.setOnEditorActionListener { _, actionId, _ ->
+            if (actionId == EditorInfo.IME_ACTION_SEARCH) {
+                performSearch()
+                hideKeyboard()
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    private fun performSearch() {
+        val category =
+            if (arguments?.getString(CATEGORY_PARAM1) == "서북병원") "병원" else arguments?.getString(CATEGORY_PARAM1)
+        val region = arguments?.getString(CATEGORY_PARAM2)
+
+        if (binding.etCategorySearch.text.isNotBlank()) {
+            search = binding.etCategorySearch.text.toString()
+            viewModel.updateListWithSvcstatnmPay(
+                text = search,
+                areanm = region ?: "",
+                minclassnm = category ?: "",
+                pay = payment,
+                svcstatnm = serviceState
+            )
+        } else {
+            search = ""
+            viewModel.updateList(
+                region ?: "", category ?: ""
+            )
+        }
+    }
+
+    private fun initViewModel() {
+        viewModel.categories.observe(viewLifecycleOwner) { categories ->
+            Log.d("Observe", "잘 되는지 테스트 ${categories.toString().take(255)}")
+            binding.tvCategoryEmptyDescription.isVisible = categories.isEmpty()
+            adapter.submitList(categories)
+        }
+    }
+
+    private fun categoryClick() {  // 인터페이스로 받은 svcid를 상세 페이지로 넘기기
+        adapter.categoryItemClick = object : CategoryItemClick {
+            override fun onClick(svcID: String) {
+                val dialog = DetailFragment.newInstance(svcID)
+                dialog.setCloseListener(object : DetailCloseInterface {
+                    override fun onDialogClosed() {
+                        mainViewModel.setMappingData()
+                    }
+                })
+                dialog.show(requireActivity().supportFragmentManager, "CategoryFrag")
+            }
+        }
+    }
+
+    private fun categoryFilter(text: String) {
+        when (text) {
+            "pay" -> {
+                payment = if (payment.isEmpty()) {
+                    binding.tvCtFree.setTextColor(Color.parseColor("#F8496C"))
+                    "무료"
+                } else {
+                    binding.tvCtFree.setTextColor(Color.parseColor("#8E8E8E"))
+                    ""
+                }
+            }
+
+            "svc" -> {
+                serviceState = if (serviceState.isEmpty()) {
+                    binding.tvCtIsReservationAvailable.setTextColor(Color.parseColor("#F8496C"))
+                    listOf("접수중", "안내중")
+                } else {
+                    binding.tvCtIsReservationAvailable.setTextColor(Color.parseColor("#8E8E8E"))
+                    listOf()
+                }
+            }
+        }
+
+        viewModel.updateListWithSvcstatnmPay(
+            text = search,
+            areanm = arguments?.getString(CATEGORY_PARAM2) ?: "",
+            minclassnm = arguments?.getString(CATEGORY_PARAM1) ?: "",
+            pay = payment,
+            svcstatnm = serviceState
+        )
+    }
+
+    // 키보드 숨기기
+    private fun hideKeyboard() {
+        val imm =
+            requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        imm.hideSoftInputFromWindow(binding.etCategorySearch.windowToken, 0)
+    }
+
+    companion object {
+        @JvmStatic
+        fun newInstance(category: String, region: String) =
+            CategoryFragment2().apply {
+                arguments = Bundle().apply {
+                    putString(CATEGORY_PARAM1, category)
+                    putString(CATEGORY_PARAM2, region)
+                }
+            }
+    }
+}

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/detail/DetailFragment.kt
@@ -44,7 +44,6 @@ class DetailFragment : DialogFragment(), OnMapReadyCallback {
 
     private val app by lazy { requireActivity().application as SeoulPublicServiceApplication }
     private val viewModel: DetailViewModel by viewModels { DetailViewModel.factory }
-    private val mainViewModel: MainViewModel by activityViewModels()
 
     private var param1: String? = null
     private var textOpen = false    // 텍스트 뷰가 펼쳐져 있는지(false = 접힌 상태, true = 펼친 상태)

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/dialog/filter/FilterFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/dialog/filter/FilterFragment.kt
@@ -27,7 +27,7 @@ class FilterFragment : DialogFragment() {
     private val binding get() = _binding!!
 
     private val viewModel: FilterViewModel by viewModels { FilterViewModel.factory }
-    private val mainViewModel: MainViewModel by activityViewModels()
+    private val mainViewModel: MainViewModel by activityViewModels { MainViewModel.factory }
 
     private val filterOptions by lazy {
         listOf(

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/dialog/setting/SettingDialog.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/dialog/setting/SettingDialog.kt
@@ -31,7 +31,7 @@ class SettingDialog: DialogFragment() {
     private val binding get() = _binding!!
 
     private val viewModel: SettingViewModel by viewModels { SettingViewModel.factory }
-    private val mainViewModel: MainViewModel by activityViewModels()
+    private val mainViewModel: MainViewModel by activityViewModels { MainViewModel.factory }
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/dialog/setting/SettingViewModel.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/dialog/setting/SettingViewModel.kt
@@ -61,7 +61,7 @@ class SettingViewModel(
             if (data.id.isNotEmpty() && data.name.isNotEmpty()) {
                 idPrefRepository.save(data.id)
                 namePrefRepository.save(data.name)
-                savedPrefRepository.setSvcidList(data.savedServiceList)
+                savedPrefRepository.setSvcidListForSynchronization(data.savedServiceList)
 
                 storeKeyToPref(key)
             }

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/CultureEventFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/CultureEventFragment.kt
@@ -22,7 +22,7 @@ class CultureEventFragment : Fragment() {
 
     private val regionPrefRepository by lazy { (requireActivity().application as SeoulPublicServiceApplication).container.regionPrefRepository }
     private val dbMemoryRepository by lazy { (requireActivity().application as SeoulPublicServiceApplication).container.dbMemoryRepository }
-    private val mainViewModel: MainViewModel by activityViewModels()
+    private val mainViewModel: MainViewModel by activityViewModels { MainViewModel.factory }
     private val adapter by lazy { ItemAdapter(regionPrefRepository, "문화체험") { mainViewModel.moveSelectRegions(it) } }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/CultureEventFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/CultureEventFragment.kt
@@ -13,6 +13,7 @@ import com.wannabeinseoul.seoulpublicservice.SeoulPublicServiceApplication
 import com.wannabeinseoul.seoulpublicservice.data.Item
 import com.wannabeinseoul.seoulpublicservice.data.ItemRepository
 import com.wannabeinseoul.seoulpublicservice.databinding.FragmentCultureEventBinding
+import com.wannabeinseoul.seoulpublicservice.ui.category.CategoryFragment2
 import com.wannabeinseoul.seoulpublicservice.ui.main.MainViewModel
 import com.wannabeinseoul.seoulpublicservice.ui.main.adapter.ItemAdapter
 
@@ -23,9 +24,22 @@ class CultureEventFragment : Fragment() {
     private val regionPrefRepository by lazy { (requireActivity().application as SeoulPublicServiceApplication).container.regionPrefRepository }
     private val dbMemoryRepository by lazy { (requireActivity().application as SeoulPublicServiceApplication).container.dbMemoryRepository }
     private val mainViewModel: MainViewModel by activityViewModels { MainViewModel.factory }
-    private val adapter by lazy { ItemAdapter(regionPrefRepository, "문화체험") { mainViewModel.moveSelectRegions(it) } }
+    private val adapter by lazy {
+        ItemAdapter(
+            regionPrefRepository,
+            "문화체험",
+            moveCategoryPage = { category, region ->
+                val dialog = CategoryFragment2.newInstance(category, region)
+                dialog.show(requireActivity().supportFragmentManager, "Category")
+            }
+        )
+    }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
         // Inflate the layout for this fragment
         _binding = FragmentCultureEventBinding.inflate(inflater, container, false)
         return binding.root
@@ -59,7 +73,8 @@ class CultureEventFragment : Fragment() {
                     item.copy(count = size)
                 }
 
-                binding.clCultureEventNothing.isVisible = cultureEventItems.all { it.count == 0 }
+                binding.clCultureEventNothing.isVisible =
+                    cultureEventItems.all { it.count == 0 }
                 adapter.submitList(cultureEventItems)
             }
         }

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/EducationFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/EducationFragment.kt
@@ -22,7 +22,7 @@ class EducationFragment : Fragment() {
 
     private val regionPrefRepository by lazy { (requireActivity().application as SeoulPublicServiceApplication).container.regionPrefRepository }
     private val dbMemoryRepository by lazy { (requireActivity().application as SeoulPublicServiceApplication).container.dbMemoryRepository }
-    private val mainViewModel: MainViewModel by activityViewModels()
+    private val mainViewModel: MainViewModel by activityViewModels { MainViewModel.factory }
     private val adapter by lazy { ItemAdapter(regionPrefRepository, "교육강좌") { mainViewModel.moveSelectRegions(it) } }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/EducationFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/EducationFragment.kt
@@ -13,6 +13,7 @@ import com.wannabeinseoul.seoulpublicservice.SeoulPublicServiceApplication
 import com.wannabeinseoul.seoulpublicservice.data.Item
 import com.wannabeinseoul.seoulpublicservice.data.ItemRepository
 import com.wannabeinseoul.seoulpublicservice.databinding.FragmentEducationBinding
+import com.wannabeinseoul.seoulpublicservice.ui.category.CategoryFragment2
 import com.wannabeinseoul.seoulpublicservice.ui.main.MainViewModel
 import com.wannabeinseoul.seoulpublicservice.ui.main.adapter.ItemAdapter
 
@@ -23,7 +24,16 @@ class EducationFragment : Fragment() {
     private val regionPrefRepository by lazy { (requireActivity().application as SeoulPublicServiceApplication).container.regionPrefRepository }
     private val dbMemoryRepository by lazy { (requireActivity().application as SeoulPublicServiceApplication).container.dbMemoryRepository }
     private val mainViewModel: MainViewModel by activityViewModels { MainViewModel.factory }
-    private val adapter by lazy { ItemAdapter(regionPrefRepository, "교육강좌") { mainViewModel.moveSelectRegions(it) } }
+    private val adapter by lazy {
+        ItemAdapter(
+            regionPrefRepository,
+            "교육강좌",
+            moveCategoryPage = { category, region ->
+                val dialog = CategoryFragment2.newInstance(category, region)
+                dialog.show(requireActivity().supportFragmentManager, "Category")
+            }
+        )
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         // Inflate the layout for this fragment

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/FacilityFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/FacilityFragment.kt
@@ -13,6 +13,9 @@ import com.wannabeinseoul.seoulpublicservice.SeoulPublicServiceApplication
 import com.wannabeinseoul.seoulpublicservice.data.Item
 import com.wannabeinseoul.seoulpublicservice.data.ItemRepository
 import com.wannabeinseoul.seoulpublicservice.databinding.FragmentFacilityBinding
+import com.wannabeinseoul.seoulpublicservice.ui.category.CategoryFragment2
+import com.wannabeinseoul.seoulpublicservice.ui.detail.DetailCloseInterface
+import com.wannabeinseoul.seoulpublicservice.ui.detail.DetailFragment
 import com.wannabeinseoul.seoulpublicservice.ui.main.MainViewModel
 import com.wannabeinseoul.seoulpublicservice.ui.main.adapter.ItemAdapter
 
@@ -26,8 +29,12 @@ class FacilityFragment : Fragment() {
     private val adapter by lazy {
         ItemAdapter(
             regionPrefRepository,
-            "체육시설"
-        ) { mainViewModel.moveSelectRegions(it) }
+            "체육시설",
+            moveCategoryPage = { category, region ->
+                val dialog = CategoryFragment2.newInstance(category, region)
+                dialog.show(requireActivity().supportFragmentManager, "Category")
+            }
+        )
     }
 
     override fun onCreateView(

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/FacilityFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/FacilityFragment.kt
@@ -22,7 +22,7 @@ class FacilityFragment : Fragment() {
 
     private val regionPrefRepository by lazy { (requireActivity().application as SeoulPublicServiceApplication).container.regionPrefRepository }
     private val dbMemoryRepository by lazy { (requireActivity().application as SeoulPublicServiceApplication).container.dbMemoryRepository }
-    private val mainViewModel: MainViewModel by activityViewModels()
+    private val mainViewModel: MainViewModel by activityViewModels { MainViewModel.factory }
     private val adapter by lazy {
         ItemAdapter(
             regionPrefRepository,

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/FacilityRentFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/FacilityRentFragment.kt
@@ -22,7 +22,7 @@ class FacilityRentFragment : Fragment() {
 
     private val regionPrefRepository by lazy { (requireActivity().application as SeoulPublicServiceApplication).container.regionPrefRepository }
     private val dbMemoryRepository by lazy { (requireActivity().application as SeoulPublicServiceApplication).container.dbMemoryRepository }
-    private val mainViewModel: MainViewModel by activityViewModels()
+    private val mainViewModel: MainViewModel by activityViewModels { MainViewModel.factory }
     private val adapter by lazy { ItemAdapter(regionPrefRepository, "공간시설") { mainViewModel.moveSelectRegions(it) } }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/FacilityRentFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/FacilityRentFragment.kt
@@ -13,6 +13,7 @@ import com.wannabeinseoul.seoulpublicservice.SeoulPublicServiceApplication
 import com.wannabeinseoul.seoulpublicservice.data.Item
 import com.wannabeinseoul.seoulpublicservice.data.ItemRepository
 import com.wannabeinseoul.seoulpublicservice.databinding.FragmentFacilityRentBinding
+import com.wannabeinseoul.seoulpublicservice.ui.category.CategoryFragment2
 import com.wannabeinseoul.seoulpublicservice.ui.main.MainViewModel
 import com.wannabeinseoul.seoulpublicservice.ui.main.adapter.ItemAdapter
 
@@ -23,7 +24,16 @@ class FacilityRentFragment : Fragment() {
     private val regionPrefRepository by lazy { (requireActivity().application as SeoulPublicServiceApplication).container.regionPrefRepository }
     private val dbMemoryRepository by lazy { (requireActivity().application as SeoulPublicServiceApplication).container.dbMemoryRepository }
     private val mainViewModel: MainViewModel by activityViewModels { MainViewModel.factory }
-    private val adapter by lazy { ItemAdapter(regionPrefRepository, "공간시설") { mainViewModel.moveSelectRegions(it) } }
+    private val adapter by lazy {
+        ItemAdapter(
+            regionPrefRepository,
+            "공간시설",
+            moveCategoryPage = { category, region ->
+                val dialog = CategoryFragment2.newInstance(category, region)
+                dialog.show(requireActivity().supportFragmentManager, "Category")
+            }
+        )
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         // Inflate the layout for this fragment

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/HomeFragment.kt
@@ -67,7 +67,7 @@ class HomeFragment : Fragment() {
     private val binding get() = _binding!!
 
     private val homeViewModel: HomeViewModel by viewModels { HomeViewModel.factory }
-    private val mainViewModel: MainViewModel by activityViewModels()
+    private val mainViewModel: MainViewModel by activityViewModels { MainViewModel.factory }
 
     private var backPressedOnce = false
 
@@ -456,6 +456,7 @@ class HomeFragment : Fragment() {
                 val dialog = DetailFragment.newInstance(homeViewModel.randomService.random())
                 dialog.setCloseListener(object : DetailCloseInterface { // 다이얼로그 종료 리스너를 받아 onResume으로 갱신하기
                     override fun onDialogClosed() {
+                        mainViewModel.setMappingData()
                         onResume()
                     }
                 })
@@ -593,6 +594,7 @@ class HomeFragment : Fragment() {
                 val dialog = DetailFragment.newInstance(svcID)
                 dialog.setCloseListener(object : DetailCloseInterface {
                     override fun onDialogClosed() {
+                        mainViewModel.setMappingData()
                         onResume()
                     }
                 })

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/MedicalFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/MedicalFragment.kt
@@ -22,7 +22,7 @@ class MedicalFragment : Fragment() {
 
     private val regionPrefRepository by lazy { (requireActivity().application as SeoulPublicServiceApplication).container.regionPrefRepository }
     private val dbMemoryRepository by lazy { (requireActivity().application as SeoulPublicServiceApplication).container.dbMemoryRepository }
-    private val mainViewModel: MainViewModel by activityViewModels()
+    private val mainViewModel: MainViewModel by activityViewModels { MainViewModel.factory }
     private val adapter by lazy { ItemAdapter(regionPrefRepository, "진료복지") { mainViewModel.moveSelectRegions(it) } }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/MedicalFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/home/MedicalFragment.kt
@@ -13,6 +13,7 @@ import com.wannabeinseoul.seoulpublicservice.SeoulPublicServiceApplication
 import com.wannabeinseoul.seoulpublicservice.data.Item
 import com.wannabeinseoul.seoulpublicservice.data.ItemRepository
 import com.wannabeinseoul.seoulpublicservice.databinding.FragmentMedicalBinding
+import com.wannabeinseoul.seoulpublicservice.ui.category.CategoryFragment2
 import com.wannabeinseoul.seoulpublicservice.ui.main.MainViewModel
 import com.wannabeinseoul.seoulpublicservice.ui.main.adapter.ItemAdapter
 
@@ -23,7 +24,16 @@ class MedicalFragment : Fragment() {
     private val regionPrefRepository by lazy { (requireActivity().application as SeoulPublicServiceApplication).container.regionPrefRepository }
     private val dbMemoryRepository by lazy { (requireActivity().application as SeoulPublicServiceApplication).container.dbMemoryRepository }
     private val mainViewModel: MainViewModel by activityViewModels { MainViewModel.factory }
-    private val adapter by lazy { ItemAdapter(regionPrefRepository, "진료복지") { mainViewModel.moveSelectRegions(it) } }
+    private val adapter by lazy {
+        ItemAdapter(
+            regionPrefRepository,
+            "진료복지",
+            moveCategoryPage = { category, region ->
+                val dialog = CategoryFragment2.newInstance(category, region)
+                dialog.show(requireActivity().supportFragmentManager, "Category")
+            }
+        )
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         // Inflate the layout for this fragment

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/main/MainViewModel.kt
@@ -3,11 +3,32 @@ package com.wannabeinseoul.seoulpublicservice.ui.main
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.wannabeinseoul.seoulpublicservice.SeoulPublicServiceApplication
+import com.wannabeinseoul.seoulpublicservice.databases.ReservationEntity
+import com.wannabeinseoul.seoulpublicservice.ui.map.DetailInfoWindow
+import com.wannabeinseoul.seoulpublicservice.ui.map.MapViewModel
+import com.wannabeinseoul.seoulpublicservice.usecase.FilterServiceDataOnMapUseCase
+import com.wannabeinseoul.seoulpublicservice.usecase.GetSavedServiceUseCase
+import com.wannabeinseoul.seoulpublicservice.usecase.LoadSavedFilterOptionsUseCase
+import com.wannabeinseoul.seoulpublicservice.usecase.MappingDetailInfoWindowUseCase
+import com.wannabeinseoul.seoulpublicservice.usecase.SearchServiceDataOnMapUseCase
 
-class MainViewModel: ViewModel() {
+class MainViewModel(
+    private val loadSavedFilterOptionsUseCase: LoadSavedFilterOptionsUseCase,
+    private val filterServiceDataOnMapUseCase: FilterServiceDataOnMapUseCase,
+    private val searchServiceDataOnMapUseCase: SearchServiceDataOnMapUseCase,
+    private val mappingDetailInfoWindowUseCase: MappingDetailInfoWindowUseCase,
+    private val getSavedServiceUseCase: GetSavedServiceUseCase
+): ViewModel() {
 
     private var _selectedServiceId: String = ""
     val selectedServiceId: String get() = _selectedServiceId
+
+    private var _prevSavedServices: List<String> = listOf()
+    val prevSavedServices: List<String> get() = _prevSavedServices
 
     private var _userName: MutableLiveData<String> = MutableLiveData()
     val userName: LiveData<String> get() = _userName
@@ -23,6 +44,10 @@ class MainViewModel: ViewModel() {
 
     private val _applySynchronization: MutableLiveData<List<String>> = MutableLiveData()
     val applySynchronization: LiveData<List<String>> get() = _applySynchronization
+
+    private val _mappingData: MutableLiveData<HashMap<Pair<String, String>, List<DetailInfoWindow>>> =
+        MutableLiveData()
+    val mappingData: LiveData<HashMap<Pair<String, String>, List<DetailInfoWindow>>> get() = _mappingData
 
     fun setFilterState(flag: Boolean) {
         _applyFilter.value = flag
@@ -47,5 +72,58 @@ class MainViewModel: ViewModel() {
     fun synchronizeData(name: String, list: List<String>) {
         _userName.value = name
         _applySynchronization.value = list
+    }
+
+    fun setMappingData(isSearch: Boolean = false) {
+        val savedOptions = loadSavedFilterOptionsUseCase()
+        val list = getSavedServiceUseCase().getSvcidList()
+
+        if (isSearch || _prevSavedServices != list) {
+            val filteringData = filterServiceDataOnMapUseCase(savedOptions)
+            val mappingData: HashMap<Pair<String, String>, List<DetailInfoWindow>> = hashMapOf()
+
+            filteringData.forEach {
+                mappingData[it.key] = mappingDetailInfoWindowUseCase(it.value)
+            }
+
+            _mappingData.value = mappingData
+        }
+
+        _prevSavedServices = list
+    }
+
+
+    fun setMappingData(word: String, isSearch: Boolean = false) {
+        val savedOptions = loadSavedFilterOptionsUseCase()
+        val list = getSavedServiceUseCase().getSvcidList()
+
+        if (isSearch || _prevSavedServices != list) {
+            val filteringData = searchServiceDataOnMapUseCase(word, savedOptions)
+            val mappingData: HashMap<Pair<String, String>, List<DetailInfoWindow>> = hashMapOf()
+
+            filteringData.forEach {
+                mappingData[it.key] = mappingDetailInfoWindowUseCase(it.value)
+            }
+
+            _mappingData.value = mappingData
+        }
+
+        _prevSavedServices = list
+    }
+
+    companion object {
+        val factory = viewModelFactory {
+            initializer {
+                val application = (this[ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY] as SeoulPublicServiceApplication)
+                val container = application.container
+                MainViewModel(
+                    loadSavedFilterOptionsUseCase = container.loadSavedFilterOptionsUseCase,
+                    filterServiceDataOnMapUseCase = container.filterServiceDataOnMapUseCase,
+                    getSavedServiceUseCase = container.getSavedServiceUseCase,
+                    mappingDetailInfoWindowUseCase = container.mappingDetailInfoWindowUseCase,
+                    searchServiceDataOnMapUseCase = container.searchServiceDataOnMapUseCase
+                )
+            }
+        }
     }
 }

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/main/MainViewModel.kt
@@ -24,6 +24,9 @@ class MainViewModel(
     private val getSavedServiceUseCase: GetSavedServiceUseCase
 ): ViewModel() {
 
+    private var _isSearch: Boolean = false
+    val isSearch: Boolean get() = _isSearch
+
     private var _selectedServiceId: String = ""
     val selectedServiceId: String get() = _selectedServiceId
 
@@ -86,6 +89,7 @@ class MainViewModel(
                 mappingData[it.key] = mappingDetailInfoWindowUseCase(it.value)
             }
 
+            _isSearch = isSearch
             _mappingData.value = mappingData
         }
 
@@ -105,6 +109,7 @@ class MainViewModel(
                 mappingData[it.key] = mappingDetailInfoWindowUseCase(it.value)
             }
 
+            _isSearch = isSearch
             _mappingData.value = mappingData
         }
 

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/main/adapter/ItemAdapter.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/main/adapter/ItemAdapter.kt
@@ -18,7 +18,7 @@ import com.wannabeinseoul.seoulpublicservice.ui.category.CategoryActivity
 class ItemAdapter(
     private val regionPrefRepository: RegionPrefRepository,
     private val maxClass: String,
-    private val moveReselect: (Boolean) -> Unit
+    private val moveCategoryPage: (String, String) -> Unit
 ) : ListAdapter<Item, ItemAdapter.ItemViewHolder>(object : DiffUtil.ItemCallback<Item>() {
     override fun areItemsTheSame(oldItem: Item, newItem: Item): Boolean {
         return oldItem.name == newItem.name
@@ -31,7 +31,7 @@ class ItemAdapter(
 }) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ItemViewHolder {
         val binding = ItemHomeBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return ItemViewHolder(binding, moveReselect)
+        return ItemViewHolder(binding, moveCategoryPage)
     }
 
     override fun onBindViewHolder(holder: ItemViewHolder, position: Int) {
@@ -42,7 +42,7 @@ class ItemAdapter(
         return currentList.size
     }
 
-    inner class ItemViewHolder(val binding: ItemHomeBinding, private val moveReselect: (Boolean) -> Unit) : RecyclerView.ViewHolder(binding.root) {
+    inner class ItemViewHolder(private val binding: ItemHomeBinding, private val moveCategoryPage: (String, String) -> Unit) : RecyclerView.ViewHolder(binding.root) {
         fun bind(item: Item) = with(binding) {
             ivIcon.setImageResource(item.icon)
             tvName.text = item.name
@@ -62,55 +62,31 @@ class ItemAdapter(
                     // 아이콘의 배경색과 색상을 변경
                     setClickedIconColor()
                     // 선택된 항목의 데이터와 지역을 가지고 카테고리 페이지로 이동
-                    val intent = Intent(it.context, CategoryActivity::class.java).apply {
-                        if (item.name == "병원") {
-                            putExtra("category", "서북병원")
-                        } else {
-                            putExtra("category", item.name)
-                        }
-
-                        val region = regionPrefRepository.loadSelectedRegion()
-                        if (region == "지역선택") {
-                            putExtra("region", "")
-                        } else {
-                            putExtra("region", region)
-                        }
-                    }
-                    Log.d(
-                        "ItemAdapter",
-                        "Moving to CategoryActivity with category: ${item.name}, region: ${regionPrefRepository.loadSelectedRegion()}"
-                    )
-                    it.context.startActivity(intent)
+                    val region = regionPrefRepository.loadSelectedRegion()
+                    moveCategoryPage(if (item.name == "병원") "서북병원" else item.name, if (region == "지역선택") "" else region)
+//                    val intent = Intent(it.context, CategoryActivity::class.java).apply {
+//                        if (item.name == "병원") {
+//                            putExtra("category", "서북병원")
+//                        } else {
+//                            putExtra("category", item.name)
+//                        }
+//
+//                        val region = regionPrefRepository.loadSelectedRegion()
+//                        if (region == "지역선택") {
+//                            putExtra("region", "")
+//                        } else {
+//                            putExtra("region", region)
+//                        }
+//                    }
+//                    Log.d(
+//                        "ItemAdapter",
+//                        "Moving to CategoryActivity with category: ${item.name}, region: ${regionPrefRepository.loadSelectedRegion()}"
+//                    )
+//                    it.context.startActivity(intent)
                     // 일정 시간 후에 아이콘의 배경색과 색상을 원래대로 복원
                     itemView.postDelayed({
                         setIconColor()
                     }, 500)
-//                    if (regionPrefRepository.loadSelectedRegion() == "지역선택") {
-//                        Toast.makeText(it.context, "관심지역을 먼저 선택해주세요.", Toast.LENGTH_SHORT).show()
-//                        moveReselect(true)
-//                    } else {
-//                        // 아이콘의 배경색과 색상을 변경
-//                        setClickedIconColor()
-//                        // 선택된 항목의 데이터와 지역을 가지고 카테고리 페이지로 이동
-//                        val intent = Intent(it.context, CategoryActivity::class.java).apply {
-//                            if (item.name == "병원") {
-//                                putExtra("category", "서북병원")
-//                            } else {
-//                                putExtra("category", item.name)
-//                            }
-//
-//                            putExtra("region", regionPrefRepository.loadSelectedRegion())
-//                        }
-//                        Log.d(
-//                            "ItemAdapter",
-//                            "Moving to CategoryActivity with category: ${item.name}, region: ${regionPrefRepository.loadSelectedRegion()}"
-//                        )
-//                        it.context.startActivity(intent)
-//                        // 일정 시간 후에 아이콘의 배경색과 색상을 원래대로 복원
-//                        itemView.postDelayed({
-//                            setIconColor()
-//                        }, 500)
-//                    }
                 }
             }
         }

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/DetailInfoWindow.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/DetailInfoWindow.kt
@@ -1,6 +1,7 @@
 package com.wannabeinseoul.seoulpublicservice.ui.map
 
 data class DetailInfoWindow(
+    val maxclassnm: String,
     val svcid: String,
     val imgurl: String,
     val areanm: String,

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapFragment.kt
@@ -59,7 +59,6 @@ class MapFragment : Fragment(), OnMapReadyCallback {
         MapDetailInfoAdapter(
             saveService = { id ->
                 viewModel.saveService(id)
-                mainViewModel.setMappingData()
             },
             moveReservationPage = { url ->
                 backFromClickMarker()
@@ -229,12 +228,14 @@ class MapFragment : Fragment(), OnMapReadyCallback {
                 it.map = null
             }
             activeMarkers.clear()
-              // 다른 페이지에서 공유뷰모델을 이용하여 데이터를 변경할 때마다 다 뜨기 때문에 방법을 찾기 전까지는 제외해놓음
-//            if (dataSet.size == 0) {
-//                toastShort(requireContext(), "필터링 결과가 없습니다.")
-//            } else {
-//                toastShort(requireContext(), "${filteringData.value?.size}+개의 서비스가 있습니다.")
-//            }
+            // 다른 페이지에서 공유뷰모델을 이용하여 데이터를 변경할 때마다 다 뜨기 때문에 방법을 찾기 전까지는 제외해놓음
+            if (mainViewModel.isSearch) {
+                if (dataSet.size == 0) {
+                    toastShort(requireContext(), "필터링 결과가 없습니다.")
+                } else {
+                    toastShort(requireContext(), "${filteringData.value?.size}+개의 서비스가 있습니다.")
+                }
+            }
 
             dataSet.forEach {
                 val marker = Marker()
@@ -271,7 +272,6 @@ class MapFragment : Fragment(), OnMapReadyCallback {
     }
 
     override fun onMapReady(map: NaverMap) {
-
         naverMap = map
         map.maxZoom = 18.0
         map.minZoom = 9.0

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapViewModel.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/map/MapViewModel.kt
@@ -16,6 +16,7 @@ import com.wannabeinseoul.seoulpublicservice.usecase.MappingDetailInfoWindowUseC
 import com.wannabeinseoul.seoulpublicservice.usecase.SaveServiceUseCase
 import com.wannabeinseoul.seoulpublicservice.usecase.SearchServiceDataOnMapUseCase
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.invoke
 import kotlinx.coroutines.launch
 
 class MapViewModel(
@@ -29,6 +30,7 @@ class MapViewModel(
 
     private var readyMap: Boolean = false
     private var readyData: Boolean = false
+    private var searchWord = ""
 
     private var _filterCount: Int = 0
     val filterCount: Int get() = _filterCount
@@ -74,6 +76,19 @@ class MapViewModel(
             if (readyMap) {
                 _canStart.postValue(true)
             }
+        }
+    }
+
+    fun updateServiceData(word: String) {
+        val savedOptions = loadSavedOptions()
+        searchWord = word
+
+        _filterCount = savedOptions.count { it.isNotEmpty() }
+
+        viewModelScope.launch(Dispatchers.IO) {
+            _filteringData.postValue(searchServiceDataOnMapUseCase(searchWord, savedOptions))
+
+            _canStart.postValue(true)
         }
     }
 

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/mypage/EditProfileDialog.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/mypage/EditProfileDialog.kt
@@ -56,7 +56,7 @@ class EditProfileDialog : DialogFragment() {
     private val container by lazy { app.container }
     private val id by lazy { container.idPrefRepository.load() }
 
-    private val mainViewModel: MainViewModel by activityViewModels()
+    private val mainViewModel: MainViewModel by activityViewModels { MainViewModel.factory }
 
     private val imm by lazy {
         requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/mypage/MyPageFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/mypage/MyPageFragment.kt
@@ -12,6 +12,7 @@ import androidx.fragment.app.viewModels
 import com.wannabeinseoul.seoulpublicservice.R
 import com.wannabeinseoul.seoulpublicservice.SeoulPublicServiceApplication
 import com.wannabeinseoul.seoulpublicservice.databinding.FragmentMyPageBinding
+import com.wannabeinseoul.seoulpublicservice.ui.detail.DetailCloseInterface
 
 import com.wannabeinseoul.seoulpublicservice.ui.detail.DetailFragment
 import com.wannabeinseoul.seoulpublicservice.ui.dialog.setting.SettingDialog
@@ -28,13 +29,18 @@ class MyPageFragment : Fragment() {
     private var _binding: FragmentMyPageBinding? = null
     private val binding get() = _binding!!
     private val viewModel: MyPageViewModel by viewModels { MyPageViewModel.factory }
-    private val mainViewModel: MainViewModel by activityViewModels()
+    private val mainViewModel: MainViewModel by activityViewModels { MainViewModel.factory }
 
     private val app by lazy { requireActivity().application as SeoulPublicServiceApplication }
 
     private val showDetailFragment = { svcid: String ->
-        DetailFragment.newInstance(svcid)
-            .show(requireActivity().supportFragmentManager, "Detail")
+        val dialog = DetailFragment.newInstance(svcid)
+        dialog.setCloseListener(object : DetailCloseInterface {
+            override fun onDialogClosed() {
+                mainViewModel.setMappingData()
+            }
+        })
+        dialog.show(requireActivity().supportFragmentManager, "Detail")
     }
 
     private val showSettingDialog = {

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/notifications/NotificationsFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/notifications/NotificationsFragment.kt
@@ -25,11 +25,17 @@ class NotificationsFragment : DialogFragment() {
     private val binding get() = _binding!!
 
     private val viewModel: NotificationsViewModel by viewModels { NotificationsViewModel.factory }
+    private val mainViewModel: MainViewModel by activityViewModels { MainViewModel.factory }
 
     private val adapter: NotificationAdapter by lazy {
         NotificationAdapter(
             moveDetail = {
                 val dialog = DetailFragment.newInstance(it)
+                dialog.setCloseListener(object : DetailCloseInterface {
+                    override fun onDialogClosed() {
+                        mainViewModel.setMappingData()
+                    }
+                })
                 dialog.show(requireActivity().supportFragmentManager, "Detail")
                 dismiss()
             }

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/recommendation/RecommendationFragment.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/ui/recommendation/RecommendationFragment.kt
@@ -7,12 +7,15 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.wannabeinseoul.seoulpublicservice.R
 import com.wannabeinseoul.seoulpublicservice.databinding.FragmentRecommendationBinding
+import com.wannabeinseoul.seoulpublicservice.ui.detail.DetailCloseInterface
 import com.wannabeinseoul.seoulpublicservice.ui.detail.DetailFragment
+import com.wannabeinseoul.seoulpublicservice.ui.main.MainViewModel
 import com.wannabeinseoul.seoulpublicservice.ui.recommendation.RecommendationViewModel.Companion.factory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -22,11 +25,17 @@ class RecommendationFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener 
 
     private lateinit var binding: FragmentRecommendationBinding
     private val viewModel: RecommendationViewModel by viewModels { factory }
+    private val mainViewModel: MainViewModel by activityViewModels { factory }
 
     private val showDetailFragment: (RecommendationData) -> Unit =
         { recommendationData: RecommendationData ->
-            DetailFragment.newInstance(recommendationData.svcid)
-                .show(requireActivity().supportFragmentManager, "Detail")
+            val dialog = DetailFragment.newInstance(recommendationData.svcid)
+            dialog.setCloseListener(object : DetailCloseInterface {
+                override fun onDialogClosed() {
+                    mainViewModel.setMappingData()
+                }
+            })
+            dialog.show(requireActivity().supportFragmentManager, "Detail")
         }
 
     private val recommendationAdapter = RecommendationAdapter()

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/usecase/MappingDetailInfoWindowUseCase.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/usecase/MappingDetailInfoWindowUseCase.kt
@@ -7,6 +7,7 @@ import com.wannabeinseoul.seoulpublicservice.ui.map.DetailInfoWindow
 class MappingDetailInfoWindowUseCase(
     private val savedPrefRepository: SavedPrefRepository
 ) {
+    val list = savedPrefRepository.getSvcidList()
     operator fun invoke(serviceInfoList: List<ReservationEntity>): List<DetailInfoWindow> = serviceInfoList.map {
         DetailInfoWindow(
             svcid = it.SVCID,
@@ -16,7 +17,7 @@ class MappingDetailInfoWindowUseCase(
             payatnm = it.PAYATNM,
             svcstatnm = it.SVCSTATNM,
             svcurl = it.SVCURL,
-            saved = savedPrefRepository.contains(it.SVCID)
+            saved = list.contains(it.SVCID)
         )
     }
 }

--- a/app/src/main/java/com/wannabeinseoul/seoulpublicservice/usecase/MappingDetailInfoWindowUseCase.kt
+++ b/app/src/main/java/com/wannabeinseoul/seoulpublicservice/usecase/MappingDetailInfoWindowUseCase.kt
@@ -7,17 +7,21 @@ import com.wannabeinseoul.seoulpublicservice.ui.map.DetailInfoWindow
 class MappingDetailInfoWindowUseCase(
     private val savedPrefRepository: SavedPrefRepository
 ) {
-    val list = savedPrefRepository.getSvcidList()
-    operator fun invoke(serviceInfoList: List<ReservationEntity>): List<DetailInfoWindow> = serviceInfoList.map {
-        DetailInfoWindow(
-            svcid = it.SVCID,
-            imgurl = it.IMGURL,
-            areanm = it.AREANM,
-            svcnm = it.SVCNM,
-            payatnm = it.PAYATNM,
-            svcstatnm = it.SVCSTATNM,
-            svcurl = it.SVCURL,
-            saved = list.contains(it.SVCID)
-        )
+    operator fun invoke(serviceInfoList: List<ReservationEntity>): List<DetailInfoWindow> {
+        val list = savedPrefRepository.getSvcidList()
+
+        return serviceInfoList.map {
+            DetailInfoWindow(
+                maxclassnm = it.MAXCLASSNM,
+                svcid = it.SVCID,
+                imgurl = it.IMGURL,
+                areanm = it.AREANM,
+                svcnm = it.SVCNM,
+                payatnm = it.PAYATNM,
+                svcstatnm = it.SVCSTATNM,
+                svcurl = it.SVCURL,
+                saved = list.contains(it.SVCID)
+            )
+        }
     }
 }


### PR DESCRIPTION
## PR 체크리스트
다음 요구사항을 충족하는지 확인해주세요

- [x] 커밋메세지 규칙을 따릅니다.

## PR 유형
어떤 변경사항이 있는지 모두 체크해 주세요

- [ ] 기능구현
- [x] 버그픽스
- [x] 리팩토링
- [ ] 문서 변경
- [ ] 레이아웃
- [ ] 기타

## 변경사항 작성

-기능
저장 기능 오류 개선

-설명
문제)
저장을 마커 정보창에서 하고 상세 정보창이나 저장한 공공서비스 목록에서 해제를 한 다음에 다시 마커 정보창을 켰을 때 반영이 되지 않는 문제를 맞닿뜨렸다.
최근에 들어갔던 공공서비스도 동일한 문제였고 반대의 케이스도 제대로 작동하지 않았다.

해결)
공유 뷰모델을 사용함
사실 저장 기능을 사용할 수 있는건 상세 페이지와 마커 정보창 뿐임
그래서 상세 페이지가 dismiss되어 인터페이스 함수가 호출될 때 MainViewModel의 setMappingData 함수를 호출함
거기서 이전에 MapViewModel에서 하던 데이터 필터링 데이터 불러오는 것과 매핑하는 작업을 한번에 함
그 값을 라이브데이터에 저장하고 이걸 MapFragment에서 옵저빙하도록 함
옵저빙을 해서 값을 받으면 MapViewModel로 넘긴 다음 값을 UI에서 처리함
이렇게 되면 상세 페이지를 사용하는 모든 부분에서는 이 방식으로 해결이 됨
(이거 때문에 많은 파일에서 수정사항이 생김...ㅎ)

마커 정보창 같은 경우에도 상세 페이지와 거의 동일하다
그냥 버튼을 누를 때 SharedPreference에 저장하고 MainViewModel의 setMappingData 함수를 호출했다.

현재)
알림 페이지, 메인 페이지의 랜덤 배너, 최근에 들어갔던 서비스, 마이 페이지의 저장한 공공서비스, 지도 페이지에서 접근한 상세 페이지에서는 이제 저장 기능이 제대로 동작하여 여기서는 저장되고 저기서는 안 되는 케이스가 사라졌다.

대신에 생긴 문제는 마커 정보창에서 저장 기능을 사용하면 마커가 클릭된 걸 알려주는 아이콘 색상이 초기상태로 돌아가버린다...
이건 아직 방법을 못 찾았다.

또 몇개의 서비스가 있는지 알려주는 토스트 메세지가 있는데 공유뷰모델을 사용하다보니 지도 페이지에서만 토스트 메세지가 나오는 것이 아니라 다른 어느 페이지에서 상세 페이지를 들어갔다 나오면 해당 토스트 메세지가 출력되는 문제가 있다.
일단은 주석 처리해놨고 어떤 방식으로 해결해야할지 고민중이다.

마지막으로 가장 큰 건 카테고리 페이지다...
이 페이지는 개별의 액티비티를 가지고 있어 공유 뷰모델을 사용할 수 없다. 생각하기로는 액티비티를 없애고 프래그먼트를 MainActivity에 속하도록 해야할 거 같다.
그렇게만 변경하면 위의 방식과 동일하게 해당 기능을 적용할 수 있다.

================================================================================

문제)
1. 대신에 생긴 문제는 마커 정보창에서 저장 기능을 사용하면 마커가 클릭된 걸 알려주는 아이콘 색상이 초기상태로 돌아가버린다...

2. 몇개의 서비스가 있는지 알려주는 토스트 메세지가 있는데 공유뷰모델을 사용하다보니 지도 페이지에서만 토스트 메세지가 나오는 것이 아니라 다른 어느 페이지에서 상세 페이지를 들어갔다 나오면 해당 토스트 메세지가 출력되는 문제가 있다.

3. 카테고리 페이지는 개별의 액티비티를 가지고 있어 공유 뷰모델을 사용할 수 없다. 생각하기로는 액티비티를 없애고 프래그먼트를 MainActivity에 속하도록 해야할 거 같다.
그렇게만 변경하면 위의 방식과 동일하게 해당 기능을 적용할 수 있다.

해결)
1. 간단하게 MapFragment의 62번째 줄의 MainViewModel의 setMappingData 함수를 제거하니까 해결됨

2. MainViewModel에 지도 페이지에서 검색이나 필터를 사용했는지 체크하는 변수를 두고 이게 true일 때마 토스트 메세지를 출력하도록 변경하여 해결

3. 카테고리 페이지로 이동할 때 카테고리 액티비티를 거치지 않고 바로 카테고리 프래그먼트를 생성해 페이지를 이동하도록 변경. 이 때 DialogFragment를 사용. newInstance함수와 initView, onCreateDialog 함수만 변경됨. 또한 ItemAdapter에서 바로 Intent를 가지고 액티비티로 이동하던 코드를 고차함수를 사용해 각각의 대분류 프래그먼트에서 카테고리 페이지로 이동시키게 함.

현재)
또 무슨 오류가 발생할지 모르겠지만 현재로서는 저장 기능이 원했던 대로 잘 동작함.
이게 merge 되고 나면 지우지 않은 카테고리 페이지 관련 이전 파일들을 삭제할 예정

## Merge 후 브랜치 보존 여부
(합친 브랜치는 삭제하는 것을 기본값으로 합니다. 브랜치를 유지할 필요가 있는 경우에 체크해주시기 바랍니다.)

- [ ] 반영된 브랜치 보존